### PR TITLE
Return normal Python integer as Dataset.size property

### DIFF
--- a/h5pyd/_hl/dataset.py
+++ b/h5pyd/_hl/dataset.py
@@ -295,7 +295,7 @@ class Dataset(HLObject):
         """Numpy-style attribute giving the total dataset size"""
         if self._shape is None:
             return 0
-        return numpy.prod(self._shape)
+        return numpy.prod(self._shape).item()
 
     @property
     def dtype(self):


### PR DESCRIPTION
The Dataset.size property returns a scalar numpy.ndarray value which creates `TypeError` exceptions when encoding that value into JSON. This PR fixes this by ensuring that the return value is a normal Python integer.