### PR TITLE
h5pyd._hl.folders.Folder.__repr__() and .domain fail on root folder #72

### DIFF
--- a/h5pyd/_hl/folders.py
+++ b/h5pyd/_hl/folders.py
@@ -30,14 +30,23 @@ class Folder():
 
     @property
     def domain(self):
-        return self._domain + '/'
+        domain = self._domain
+        if domain is None:
+            domain = ''
+
+        r = six.u(domain + '/')
+
+        if six.PY3:
+            return r
+        else:
+            return r.encode('utf8')
 
     @property
     def parent(self):
-        parent = op.dirname(self._domain)
-        if not parent:
+        if self._domain is None:
             return None
-        return parent + '/'
+        else:
+            return op.dirname(self._domain) + '/'
 
 
     @property
@@ -366,8 +375,4 @@ class Folder():
 
     def __repr__(self):
 
-        r = six.u(self._domain + '/')
-
-        if six.PY3:
-            return r
-        return r.encode('utf8')
+        return self.domain

--- a/test/test_folder.py
+++ b/test/test_folder.py
@@ -161,6 +161,9 @@ class TestFolders(TestCase):
         found = False
         self.assertTrue(len(dir) > 0)
         self.assertTrue(dir.is_folder)
+        self.assertTrue(dir.domain == '/')
+        self.assertTrue(dir.__repr__() == '/')
+        self.assertIsNone(dir.parent)
         for name in dir:
             # we should come across the given domain
             if top_level_domain == name:


### PR DESCRIPTION
Fixed errors `Folder.domain`, `Folder.parent`, and `Folder.__repr__()` when called from the root folder. Calling Folder.parent returns None when used on the root folder.