### PR TITLE
WIP: Allow hsls to be used as a library

### DIFF
--- a/h5pyd/_apps/hsls.py
+++ b/h5pyd/_apps/hsls.py
@@ -1,369 +1,13 @@
-
 import sys
-import os.path as op
 import logging
-from datetime import datetime
-import h5pyd as h5py
-import numpy as np
-if __name__ == "__main__":
-    from config import Config
-else:
-    from .config import Config
-
-#
-# Print objects in a domain in the style of the hsls utilitiy
-#
-
-cfg = Config()
-
-class HSLS_Params:
-    def __init__(self):
-        self.verbose = None
-        self.showacls = None
-        self.showattrs = None
-        self.human_readable = None
-        self.pattern = None
-        self.query = None
-        self.cmd = None
-        self.hs_endpoint = None
-        self.hs_username = None
-        self.hs_password = None
-        self.hs_bucket = None
-
-def intToStr(n):
-    if cfg["human_readable"]:
-        s = "{:,}".format(n)
-    else:
-        s = "{}".format(n)
-    return s
-
-
-def format_size(n):
-    if n is None or n == ' ':
-        return ' ' * 8
-    symbol = ' '
-    if not cfg["human_readable"]:
-        return str(n)
-    # convert to common storage unit
-    for s in ('B', 'K', 'M', 'G', 'T'):
-        if n < 1024:
-            symbol = s
-            break
-        n /= 1024
-    if symbol == 'B':
-        return "{:7}B".format(n)
-    else:
-        return "{:7.1f}{}".format(n, symbol)
-
-
-def getShapeText(dset):
-    shape_text = "Scalar"
-    shape = dset.shape
-    if shape is not None:
-        shape_text = "{"
-        rank = len(shape)
-        if rank == 0:
-            shape_text += "SCALAR"
-        else:
-            for dim in range(rank):
-                if dim != 0:
-                    shape_text += ", "
-                shape_text += str(shape[dim])
-                if cfg["verbose"]:
-                    # get unlimited dimension
-                    max_extent = dset.maxshape[dim]
-                    shape_text += '/'
-                    if max_extent is None:
-                        shape_text += "Inf"
-                    else:
-                        shape_text += str(max_extent)
-        shape_text += "}"
-    return shape_text
-
-
-def visititems(name, grp, visited):
-    for k in grp:
-        item = grp.get(k, getlink=True)
-        class_name = item.__class__.__name__
-        item_name = op.join(name, k)
-        if class_name == "HardLink":
-            # follow hardlinks
-            try:
-                item = grp.get(k)
-                dump(item_name, item, visited=visited)
-            except IOError:
-                # object deleted but hardlink left?
-                desc = "{Missing hardlink object}"
-                print("{0:24} {1} {2}".format(item_name, class_name, desc))
-
-        elif class_name == "SoftLink":
-            desc = '{' + item.path + '}'
-            print("{0:24} {1} {2}".format(item_name, class_name, desc))
-        elif class_name == "ExternalLink":
-            desc = '{' + item.path + '//' + item.filename + '}'
-            print("{0:24} {1} {2}".format(item_name, class_name, desc))
-        else:
-            desc = '{Unknown Link Type}'
-            print("{0:24} {1} {2}".format(item_name, class_name, desc))
-
-
-def getTypeStr(dt):
-    # TBD: convert dt to more HDF5-like representation
-    return str(dt)
-
-
-def dump(name, obj, visited=None):
-    class_name = obj.__class__.__name__
-    desc = None
-    obj_id = None
-    if class_name in ("Dataset", "Group", "Datatype", "Table"):
-        obj_id = obj.id.id
-        if visited and obj_id in visited:
-            same_as = visited[obj_id]
-            print("{0:24} {1}, same as {2}".format(name, class_name, same_as))
-            return
-    elif class_name in ("ExternalLink", "SoftLink"):
-        pass
-    else:
-        raise TypeError("unexpected classname: {}".format(class_name))
-
-    is_dataset = False
-    if class_name in ("Dataset", "Table"):
-        is_dataset = True
-
-
-    if is_dataset:
-        desc = getShapeText(obj)
-        obj_id = obj.id.id
-    elif class_name == "Group":
-        obj_id = obj.id.id
-    elif class_name == "Datatype":
-        obj_id = obj.id.id
-    elif class_name == "SoftLink":
-        desc = '{' + obj.path + '}'
-    elif class_name == "ExternalLink":
-        desc = '{' + obj.filename + '//' + obj.path + '}'
-
-    if desc is None:
-        print("{0} {1}".format(name, class_name))
-    else:
-        print("{0} {1} {2}".format(name, class_name, desc))
-
-    if cfg["verbose"] and obj_id is not None:
-        print("    {0:>32}: {1}".format("UUID", obj_id))
-
-    if cfg["verbose"] and is_dataset and obj.shape is not None \
-            and obj.chunks is not None:
-        chunk_size = obj.dtype.itemsize
-        if isinstance(obj.chunks, dict):
-            # H5D_CHUNKED_REF layout
-            chunk_dims = obj.chunks["dims"]
-            storage_desc = "Storage " + obj.chunks["class"]
-        else:
-            chunk_dims = obj.chunks
-            storage_desc = "Storage H5D_CHUNKED"
-        for chunk_dim in chunk_dims:
-            chunk_size *= chunk_dim
-        dset_size = obj.dtype.itemsize
-        for dim_extent in obj.shape:
-            dset_size *= dim_extent
-
-        num_chunks = obj.num_chunks
-        allocated_size = obj.allocated_size
-        if num_chunks is not None and allocated_size is not None:
-            fstr = "    {0:>32}: {1} {2} bytes, {3} allocated chunks"
-            print(fstr.format("Chunks", chunk_dims, intToStr(chunk_size),
-                              intToStr(num_chunks)))
-            if dset_size > 0:
-                utilization = allocated_size / dset_size
-                fstr = "    {0:>32}: {1} logical bytes, {2} allocated bytes, {3:.2f}% utilization"
-                print(fstr.format(storage_desc, intToStr(dset_size),
-                                  intToStr(allocated_size),
-                                  utilization * 100.0))
-            else:
-                fstr = "    {0:>32}: {1} logical bytes, {2} allocated bytes"
-                print(fstr.format(storage_desc, intToStr(dset_size),
-                                  intToStr(allocated_size)))
-
-        else:
-            # verbose info not available, just show the chunk layout
-            fstr = "    {0:>32}: {1} {2} bytes"
-            print(fstr.format("Chunks", chunk_dims, intToStr(chunk_size)))
-
-        fstr = "    {0:>32}: {1}"
-        print(fstr.format("Type", getTypeStr(obj.dtype)))  # dump out type info
-
-    if cfg["showattrs"] and class_name in ("Dataset", "Table", "Group", "Datatype"):
-        # dump attributes for the object
-        for attr_name in obj.attrs:
-            attr = obj.attrs[attr_name]
-            el = "..."  # show this if the attribute is too large
-            if isinstance(attr, np.ndarray):
-                rank = len(attr.shape)
-            else:
-                rank = 0  # scalar data
-            if rank > 1:
-                val = "[" * rank + el + "]" * rank
-                print("   attr: {0:24} {1}".format(attr_name, val))
-            elif rank == 1 and attr.shape[0] > 1:
-                val = "[{},{}]".format(attr[0], el)
-                print("   attr: {0:24} {1}".format(attr_name, val))
-            else:
-                print("   attr: {0:24} {1}".format(attr_name, attr))
-
-    if visited is not None and obj_id is not None:
-        visited[obj_id] = name
-    if class_name == "Group" and visited is not None:
-        visititems(name, obj, visited)
-
-
-def dumpACL(acl):
-    perms = ""
-    if acl["create"]:
-        perms += 'c'
-    else:
-        perms += '-'
-    if acl["read"]:
-        perms += 'r'
-    else:
-        perms += '-'
-    if acl["update"]:
-        perms += 'u'
-    else:
-        perms += '-'
-    if acl["delete"]:
-        perms += 'd'
-    else:
-        perms += '-'
-    if acl["readACL"]:
-        perms += 'e'
-    else:
-        perms += '-'
-    if acl["updateACL"]:
-        perms += 'p'
-    else:
-        perms += '-'
-    print("    acl: {0:24} {1}".format(acl["userName"], perms))
-
-
-def dumpAcls(obj):
-    try:
-        acls = obj.getACLs()
-    except IOError:
-        print("read ACLs is not permitted")
-        return
-
-    for acl in acls:
-        dumpACL(acl)
-
-
-def getFolder(domain):
-    username = cfg["hs_username"]
-    password = cfg["hs_password"]
-    endpoint = cfg["hs_endpoint"]
-    bucket   = cfg["hs_bucket"]
-    pattern = cfg["pattern"]
-    query = cfg["query"]
-    batch_size = 100  # use smaller batchsize for interactively listing of large collections
-    dir = h5py.Folder(domain, endpoint=endpoint, username=username,
-                      password=password, bucket=bucket, pattern=pattern, query=query, batch_size=batch_size)
-    return dir
-
-
-def getFile(domain):
-    username = cfg["hs_username"]
-    password = cfg["hs_password"]
-    endpoint = cfg["hs_endpoint"]
-    bucket = cfg["hs_bucket"]
-    fh = h5py.File(domain, mode='r', endpoint=endpoint, username=username,
-                   password=password, bucket=bucket, use_cache=True)
-    return fh
-
-
-def visitDomains(domain, depth=1):
-    if depth == 0:
-        return 0
-
-    count = 0
-    if domain[-1] == '/':
-        domain = domain[:-1]  # strip off trailing slash
-
-    try:
-        dir = getFolder(domain + '/')
-        dir_class = "domain"
-        display_name = domain
-        num_bytes = ' '
-        if dir.is_folder:
-            dir_class = "folder"
-            display_name += '/'
-        elif cfg["verbose"]:
-            # get the number of allocated bytes
-            f = getFile(domain)
-            num_bytes = f.total_size
-            f.close()
-
-        owner = dir.owner
-        if owner is None:
-            owner = ""
-        if dir.modified is None:
-            timestamp = ""
-        else:
-            timestamp = datetime.fromtimestamp(int(dir.modified))
-
-        print("{:15} {:15} {:8} {} {}".format(owner, format_size(num_bytes),
-                                              dir_class, timestamp,
-                                              display_name))
-        count += 1
-        if cfg["showacls"]:
-            dumpAcls(dir)
-        for name in dir:
-            item = dir[name]
-            owner = item["owner"]
-            full_path = domain + '/' + name
-
-            num_bytes = " "
-            if cfg["verbose"] and "total_size" in item:
-                num_bytes = item["total_size"]
-            else:
-                 num_bytes = " "
-            dir_class = item["class"]
-            if item["lastModified"] is None:
-                timestamp = ""
-            else:
-                timestamp = datetime.fromtimestamp(int(item["lastModified"]))
-
-            print("{:15} {:15} {:8} {} {}".format(owner, format_size(num_bytes),
-                                              dir_class, timestamp,
-                                              full_path))
-            count += 1
-
-            if dir_class == "folder":
-                # recurse for folders
-                n = visitDomains(domain + '/' + name, depth=(depth - 1))
-                count += n
-
-    except IOError as oe:
-        if oe.errno in (403, 404, 410):
-            # TBD: recently created domains may not be immediately visible to
-            # the service Once the flush operation is implemented, this should
-            # be an issue for h5pyd apps
-            #
-            # Also, ignore domains for which we don't have permsssions (403)
-            pass
-        else:
-            print("error getting domain:", domain)
-            sys.exit(str(oe))
-
-    return count
-
-
+from h5pyd._hl.h5commands import HSLSCommand
 
 #
 # Usage
 #
-def printUsage():
-    print("usage: {} [-r] [-v] [-h] [--showacls] [--showattrs] [--loglevel debug|info|warning|error] [--logfile <logfile>] [-e endpoint] [-u username] [-p password] [--bucket bucketname] domains".format(cfg["cmd"]))
-    print("example: {} -r -e http://hsdshdflab.hdfgroup.org /shared/tall.h5".format(cfg["cmd"]))
+def printUsage(cmd):
+    print("usage: {} [-r] [-v] [-h] [--showacls] [--showattrs] [--loglevel debug|info|warning|error] [--logfile <logfile>] [-e endpoint] [-u username] [-p password] [--bucket bucketname] domains".format(cmd))
+    print("example: {} -r -e http://hsdshdflab.hdfgroup.org /shared/tall.h5".format(cmd))
     print("")
     print("Options:")
     print("     -v | --verbose :: verbose output")
@@ -382,31 +26,40 @@ def printUsage():
     print("     -h | --help    :: This message.")
     sys.exit()
 
-def parseCmdLineArgs():
+def main():
     argn = 1
     domains = []
-    cfg["verbose"] = False
-    cfg["showacls"] = False
-    cfg["showattrs"] = False
-    cfg["human_readable"] = False
-    cfg["pattern"] = None
-    cfg["query"] = None
-    cfg["cmd"] = sys.argv[0].split('/')[-1]
-    if cfg["cmd"].endswith(".py"):
-        cfg["cmd"] = "python " + cfg["cmd"]
+    verbose = False
+    showacls=False
+    showattrs=False
+    human_readable=False
+    pattern=None
+    query=None
+    recursive=False
+    loglevel=None
+    logfile=None
+    endpoint=None
+    username=None
+    password=None
+    bucket=None
+
+
+    cmd = sys.argv[0].split('/')[-1]
+    if cmd.endswith(".py"):
+        cmd = "python " + cmd
     while argn < len(sys.argv):
         arg = sys.argv[argn]
         val = None
         if len(sys.argv) > argn + 1:
             val = sys.argv[argn + 1]
         if arg in ("-r", "--recursive"):
-            depth = -1
+            recursive = True
             argn += 1
         elif arg in ("-v", "--verbose"):
-            cfg["verbose"] = True
+            verbose = True
             argn += 1
         elif arg in ("-H", "--human-readable"):
-            cfg["human_readable"] = True
+            human_readable = True
             argn += 1
         elif arg == "--loglevel":
             val = val.upper()
@@ -419,170 +72,47 @@ def parseCmdLineArgs():
             elif val == "ERROR":
                 loglevel = logging.ERROR
             else:
-                printUsage()
+                printUsage(cmd)
             argn += 2
         elif arg == '--logfile':
-            logfname = val
+            logfile = val
             argn += 2
         elif arg in ("-showacls", "--showacls"):
-            cfg["showacls"] = True
+            showacls = True
             argn += 1
         elif arg in ("-showattrs", "--showattrs"):
-            cfg["showattrs"] = True
+            showattrs = True
             argn += 1
         elif arg in ("-h", "--help"):
-            printUsage()
+            printUsage(cmd)
         elif arg in ("-e", "--endpoint"):
-            cfg["hs_endpoint"] = val
+            endpoint = val
             argn += 2
         elif arg in ("-u", "--username"):
-            cfg["hs_username"] = val
+            username = val
             argn += 2
         elif arg in ("-p", "--password"):
-            cfg["hs_password"] = val
+            password = val
             argn += 2
         elif arg in ("-b", "--bucket"):
-            cfg["hs_bucket"] = val
+            bucket = val
             argn += 2
         elif arg == "--pattern":
-            cfg["pattern"] = val
+            pattern = val
             argn += 2
         elif arg == "--query":
-            cfg["query"] = val
+            query = val
             argn += 2
 
         elif arg[0] == '-':
-            printUsage()
+            printUsage(cmd)
         else:
             domains.append(arg)
             argn += 1
 
-    return domains
-
-#
-# Helper function that executes the HSLS algorithm
-#
-def _execute(domains):
-    depth = 1
-    loglevel = logging.ERROR
-    logfname = None
-
-    # setup logging
-    logging.basicConfig(filename=logfname, format='%(levelname)s %(asctime)s %(message)s',
-                        level=loglevel)
-    logging.debug("set log_level to {}".format(loglevel))
-
-    if len(domains) == 0:
-        # add top-level domain
-        domains.append("/")
-
-    for domain in domains:
-        if domain.endswith('/'):
-            # given a folder path
-            count = visitDomains(domain, depth=depth)
-            print("{} items".format(count))
-
-        else:
-            try:
-                f = getFile(domain)
-            except IOError as ioe:
-                if ioe.errno == 401:
-                    print("Username/Password missing or invalid")
-                    continue
-                if ioe.errno == 403:
-                    print("No permission to read domain: {}".format(domain))
-                    continue
-                elif ioe.errno == 404:
-                    print("Domain {} not found".format(domain))
-                    continue
-                elif ioe.errno == 410:
-                    print("Domain {} has been removed".format(domain))
-                    continue
-                else:
-                    print("Unexpected error: {}".format(ioe))
-                    continue
-
-            grp = f['/']
-            if grp is None:
-                print("{}: No such domain".format(domain))
-                domain += '/'
-                count = visitDomains(domain, depth=depth)
-                print("{} items".format(count))
-                continue
-            dump('/', grp)
-
-            if depth < 0:
-                # recursive
-                visited = {}  # dict of id to h5path
-                visited[grp.id.id] = '/'
-                visititems('/', grp, visited)
-            else:
-                for k in grp:
-                    item = grp.get(k, getlink=True)
-                    if item.__class__.__name__ == "HardLink":
-                        # follow hardlinks
-                        try:
-                            item = grp[k]
-                        except IOError:
-                            # object deleted?  Just dump link info
-                            pass
-                    dump(k, item)
-            if cfg["showacls"]:
-                dumpAcls(grp)
-            grp.file.close()
-
-#
-# Execute method to be called directly from outside Python code.
-# Requires the domain and an input parameters object
-#
-def listDomainsContents(domains, params = HSLS_Params()):
-    # Config defaults
-    if cfg.__contains__('verbose') is False:
-        cfg['verbose'] = False
-    if cfg.__contains__('showacls') is False:
-        cfg['showacls'] = False
-    if cfg.__contains__('showattrs') is False:
-        cfg['showattrs'] = False
-    if cfg.__contains__('human_readable') is False:
-        cfg['human_readable'] = False
-
-    # Add params to config object
-    if params.verbose is not None:
-        cfg['verbose'] = params.verbose
-    if params.showacls is not None:
-        cfg['showacls'] = params.showacls
-    if params.showattrs is not None:
-        cfg['showattrs'] = params.showattrs
-    if params.human_readable is not None:
-        cfg['human_readable'] = params.human_readable
-    if params.pattern is not None:
-        cfg['pattern'] = params.pattern
-    if params.query is not None:
-        cfg['query'] = params.query
-    if params.cmd is not None:
-        cfg['cmd'] = params.cmd
-    if params.hs_endpoint is not None:
-        cfg['hs_endpoint'] = params.hs_endpoint
-    if params.hs_username is not None:
-        cfg['hs_username'] = params.hs_username
-    if params.hs_password is not None:
-        cfg['hs_password'] = params.hs_password
-    if params.hs_bucket is not None:
-        cfg['hs_bucket'] = params.hs_bucket
-
-    _execute(domains)
-
-#
-# Execute method to be called directly from outside Python code.
-# Requires the domain and an input parameters object
-#
-def listDomainContents(domain, params = HSLS_Params()):
-    domains = [domain]
-    listDomainsContents(domains, params)
-
-def main():
-    domains = parseCmdLineArgs()
-    _execute(domains)
+    cmd = HSLSCommand(endpoint, username, password)
+    cmd.execute(domains, verbose=verbose, showacls=showacls, showattrs=showattrs, human_readable=human_readable, pattern=pattern, 
+query=query, cmd=cmd, recursive=recursive, loglevel=loglevel, logfile=logfile, bucket=bucket)
 
 if __name__ == "__main__":
     main()

--- a/h5pyd/_apps/hsls.py
+++ b/h5pyd/_apps/hsls.py
@@ -16,6 +16,19 @@ else:
 
 cfg = Config()
 
+class HSLS_Params:
+    def __init__(self):
+        self.verbose = None
+        self.showacls = None
+        self.showattrs = None
+        self.human_readable = None
+        self.pattern = None
+        self.query = None
+        self.cmd = None
+        self.hs_endpoint = None
+        self.hs_username = None
+        self.hs_password = None
+        self.hs_bucket = None
 
 def intToStr(n):
     if cfg["human_readable"]:
@@ -369,16 +382,9 @@ def printUsage():
     print("     -h | --help    :: This message.")
     sys.exit()
 
-
-#
-# Main
-#
-def main():
-    domains = []
+def parseCmdLineArgs():
     argn = 1
-    depth = 1
-    loglevel = logging.ERROR
-    logfname = None
+    domains = []
     cfg["verbose"] = False
     cfg["showacls"] = False
     cfg["showattrs"] = False
@@ -388,7 +394,6 @@ def main():
     cfg["cmd"] = sys.argv[0].split('/')[-1]
     if cfg["cmd"].endswith(".py"):
         cfg["cmd"] = "python " + cfg["cmd"]
-
     while argn < len(sys.argv):
         arg = sys.argv[argn]
         val = None
@@ -451,6 +456,16 @@ def main():
         else:
             domains.append(arg)
             argn += 1
+
+    return domains
+
+#
+# Helper function that executes the HSLS algorithm
+#
+def _execute(domains):
+    depth = 1
+    loglevel = logging.ERROR
+    logfname = None
 
     # setup logging
     logging.basicConfig(filename=logfname, format='%(levelname)s %(asctime)s %(message)s',
@@ -516,6 +531,58 @@ def main():
                 dumpAcls(grp)
             grp.file.close()
 
+#
+# Execute method to be called directly from outside Python code.
+# Requires the domain and an input parameters object
+#
+def listDomainsContents(domains, params):
+    # Config defaults
+    if cfg.__contains__('verbose') is False:
+        cfg['verbose'] = False
+    if cfg.__contains__('showacls') is False:
+        cfg['showacls'] = False
+    if cfg.__contains__('showattrs') is False:
+        cfg['showattrs'] = False
+    if cfg.__contains__('human_readable') is False:
+        cfg['human_readable'] = False
+
+    # Add params to config object
+    if params.verbose is not None:
+        cfg['verbose'] = params.verbose
+    if params.showacls is not None:
+        cfg['showacls'] = params.showacls
+    if params.showattrs is not None:
+        cfg['showattrs'] = params.showattrs
+    if params.human_readable is not None:
+        cfg['human_readable'] = params.human_readable
+    if params.pattern is not None:
+        cfg['pattern'] = params.pattern
+    if params.query is not None:
+        cfg['query'] = params.query
+    if params.cmd is not None:
+        cfg['cmd'] = params.cmd
+    if params.hs_endpoint is not None:
+        cfg['hs_endpoint'] = params.hs_endpoint
+    if params.hs_username is not None:
+        cfg['hs_username'] = params.hs_username
+    if params.hs_password is not None:
+        cfg['hs_password'] = params.hs_password
+    if params.hs_bucket is not None:
+        cfg['hs_bucket'] = params.hs_bucket
+
+    _execute(domains)
+
+#
+# Execute method to be called directly from outside Python code.
+# Requires the domain and an input parameters object
+#
+def listDomainContents(domain, params):
+    domains = [domain]
+    listDomainsContents(domains, params)
+
+def main():
+    domains = parseCmdLineArgs()
+    _execute(domains)
 
 if __name__ == "__main__":
     main()

--- a/h5pyd/_apps/hsls.py
+++ b/h5pyd/_apps/hsls.py
@@ -535,7 +535,7 @@ def _execute(domains):
 # Execute method to be called directly from outside Python code.
 # Requires the domain and an input parameters object
 #
-def listDomainsContents(domains, params):
+def listDomainsContents(domains, params = HSLS_Params()):
     # Config defaults
     if cfg.__contains__('verbose') is False:
         cfg['verbose'] = False
@@ -576,7 +576,7 @@ def listDomainsContents(domains, params):
 # Execute method to be called directly from outside Python code.
 # Requires the domain and an input parameters object
 #
-def listDomainContents(domain, params):
+def listDomainContents(domain, params = HSLS_Params()):
     domains = [domain]
     listDomainsContents(domains, params)
 

--- a/h5pyd/_hl/h5commands.py
+++ b/h5pyd/_hl/h5commands.py
@@ -1,0 +1,457 @@
+import sys
+import logging
+import os.path as op
+from datetime import datetime
+import h5pyd as h5py
+import numpy as np
+if __name__ == "__main__":
+    from config import Config
+else:
+    from h5pyd.config import Config
+
+class HSLSCommand():
+
+    """
+        HSLS Command Object.  Can be used to set up and execute the HSLS algorithm.
+    """
+
+    def __init__(self, endpoint, username, password):
+        """Create a new Folders object.
+
+        endpoint
+            HSDS Endpoint to access. E.g.: http://192.168.86.198:5101
+        username
+            The HSDS username to login as.
+        password
+            The password for the HSDS login.
+
+        """
+
+        self.cfg = Config()
+        self.cfg['hs_endpoint'] = endpoint
+        self.cfg['hs_username'] = username
+        self.cfg['hs_password'] = password
+
+    def intToStr(self, n):
+        if self.cfg["human_readable"]:
+            s = "{:,}".format(n)
+        else:
+            s = "{}".format(n)
+        return s
+
+    def format_size(self, n):
+        if n is None or n == ' ':
+            return ' ' * 8
+        symbol = ' '
+        if not self.cfg["human_readable"]:
+            return str(n)
+        # convert to common storage unit
+        for s in ('B', 'K', 'M', 'G', 'T'):
+            if n < 1024:
+                symbol = s
+                break
+            n /= 1024
+        if symbol == 'B':
+            return "{:7}B".format(n)
+        else:
+            return "{:7.1f}{}".format(n, symbol)
+
+    def getShapeText(self, dset):
+        shape_text = "Scalar"
+        shape = dset.shape
+        if shape is not None:
+            shape_text = "{"
+            rank = len(shape)
+            if rank == 0:
+                shape_text += "SCALAR"
+            else:
+                for dim in range(rank):
+                    if dim != 0:
+                        shape_text += ", "
+                    shape_text += str(shape[dim])
+                    if self.cfg["verbose"]:
+                        # get unlimited dimension
+                        max_extent = dset.maxshape[dim]
+                        shape_text += '/'
+                        if max_extent is None:
+                            shape_text += "Inf"
+                        else:
+                            shape_text += str(max_extent)
+            shape_text += "}"
+        return shape_text
+
+    def visititems(self, name, grp, visited):
+        for k in grp:
+            item = grp.get(k, getlink=True)
+            class_name = item.__class__.__name__
+            item_name = op.join(name, k)
+            if class_name == "HardLink":
+                # follow hardlinks
+                try:
+                    item = grp.get(k)
+                    self.dump(item_name, item, visited=visited)
+                except IOError:
+                    # object deleted but hardlink left?
+                    desc = "{Missing hardlink object}"
+                    print("{0:24} {1} {2}".format(item_name, class_name, desc))
+
+            elif class_name == "SoftLink":
+                desc = '{' + item.path + '}'
+                print("{0:24} {1} {2}".format(item_name, class_name, desc))
+            elif class_name == "ExternalLink":
+                desc = '{' + item.path + '//' + item.filename + '}'
+                print("{0:24} {1} {2}".format(item_name, class_name, desc))
+            else:
+                desc = '{Unknown Link Type}'
+                print("{0:24} {1} {2}".format(item_name, class_name, desc))
+
+    def getTypeStr(self, dt):
+        # TBD: convert dt to more HDF5-like representation
+        return str(dt)
+
+
+    def dump(self, name, obj, visited=None):
+        class_name = obj.__class__.__name__
+        desc = None
+        obj_id = None
+        if class_name in ("Dataset", "Group", "Datatype", "Table"):
+            obj_id = obj.id.id
+            if visited and obj_id in visited:
+                same_as = visited[obj_id]
+                print("{0:24} {1}, same as {2}".format(name, class_name, same_as))
+                return
+        elif class_name in ("ExternalLink", "SoftLink"):
+            pass
+        else:
+            raise TypeError("unexpected classname: {}".format(class_name))
+
+        is_dataset = False
+        if class_name in ("Dataset", "Table"):
+            is_dataset = True
+
+
+        if is_dataset:
+            desc = self.getShapeText(obj)
+            obj_id = obj.id.id
+        elif class_name == "Group":
+            obj_id = obj.id.id
+        elif class_name == "Datatype":
+            obj_id = obj.id.id
+        elif class_name == "SoftLink":
+            desc = '{' + obj.path + '}'
+        elif class_name == "ExternalLink":
+            desc = '{' + obj.filename + '//' + obj.path + '}'
+
+        if desc is None:
+            print("{0} {1}".format(name, class_name))
+        else:
+            print("{0} {1} {2}".format(name, class_name, desc))
+
+        if self.cfg["verbose"] and obj_id is not None:
+            print("    {0:>32}: {1}".format("UUID", obj_id))
+
+        if self.cfg["verbose"] and is_dataset and obj.shape is not None \
+                and obj.chunks is not None:
+            chunk_size = obj.dtype.itemsize
+            if isinstance(obj.chunks, dict):
+                # H5D_CHUNKED_REF layout
+                chunk_dims = obj.chunks["dims"]
+                storage_desc = "Storage " + obj.chunks["class"]
+            else:
+                chunk_dims = obj.chunks
+                storage_desc = "Storage H5D_CHUNKED"
+            for chunk_dim in chunk_dims:
+                chunk_size *= chunk_dim
+            dset_size = obj.dtype.itemsize
+            for dim_extent in obj.shape:
+                dset_size *= dim_extent
+
+            num_chunks = obj.num_chunks
+            allocated_size = obj.allocated_size
+            if num_chunks is not None and allocated_size is not None:
+                fstr = "    {0:>32}: {1} {2} bytes, {3} allocated chunks"
+                print(fstr.format("Chunks", chunk_dims, self.intToStr(chunk_size),
+                                self.intToStr(num_chunks)))
+                if dset_size > 0:
+                    utilization = allocated_size / dset_size
+                    fstr = "    {0:>32}: {1} logical bytes, {2} allocated bytes, {3:.2f}% utilization"
+                    print(fstr.format(storage_desc, self.intToStr(dset_size),
+                                    self.intToStr(allocated_size),
+                                    utilization * 100.0))
+                else:
+                    fstr = "    {0:>32}: {1} logical bytes, {2} allocated bytes"
+                    print(fstr.format(storage_desc, self.intToStr(dset_size),
+                                    self.intToStr(allocated_size)))
+
+            else:
+                # verbose info not available, just show the chunk layout
+                fstr = "    {0:>32}: {1} {2} bytes"
+                print(fstr.format("Chunks", chunk_dims, self.intToStr(chunk_size)))
+
+            fstr = "    {0:>32}: {1}"
+            print(fstr.format("Type", self.getTypeStr(obj.dtype)))  # dump out type info
+
+        if self.cfg["showattrs"] and class_name in ("Dataset", "Table", "Group", "Datatype"):
+            # dump attributes for the object
+            for attr_name in obj.attrs:
+                attr = obj.attrs[attr_name]
+                el = "..."  # show this if the attribute is too large
+                if isinstance(attr, np.ndarray):
+                    rank = len(attr.shape)
+                else:
+                    rank = 0  # scalar data
+                if rank > 1:
+                    val = "[" * rank + el + "]" * rank
+                    print("   attr: {0:24} {1}".format(attr_name, val))
+                elif rank == 1 and attr.shape[0] > 1:
+                    val = "[{},{}]".format(attr[0], el)
+                    print("   attr: {0:24} {1}".format(attr_name, val))
+                else:
+                    print("   attr: {0:24} {1}".format(attr_name, attr))
+
+        if visited is not None and obj_id is not None:
+            visited[obj_id] = name
+        if class_name == "Group" and visited is not None:
+            self.visititems(name, obj, visited)
+
+    def dumpACL(self, acl):
+        perms = ""
+        if acl["create"]:
+            perms += 'c'
+        else:
+            perms += '-'
+        if acl["read"]:
+            perms += 'r'
+        else:
+            perms += '-'
+        if acl["update"]:
+            perms += 'u'
+        else:
+            perms += '-'
+        if acl["delete"]:
+            perms += 'd'
+        else:
+            perms += '-'
+        if acl["readACL"]:
+            perms += 'e'
+        else:
+            perms += '-'
+        if acl["updateACL"]:
+            perms += 'p'
+        else:
+            perms += '-'
+        print("    acl: {0:24} {1}".format(acl["userName"], perms))
+
+    def dumpAcls(self, obj):
+        try:
+            acls = obj.getACLs()
+        except IOError:
+            print("read ACLs is not permitted")
+            return
+
+        for acl in acls:
+            self.dumpACL(acl)
+
+    def getFolder(self, domain):
+        username = self.cfg["hs_username"]
+        password = self.cfg["hs_password"]
+        endpoint = self.cfg["hs_endpoint"]
+        bucket   = self.cfg["hs_bucket"]
+        pattern = self.cfg["pattern"]
+        query = self.cfg["query"]
+        batch_size = 100  # use smaller batchsize for interactively listing of large collections
+        dir = h5py.Folder(domain, endpoint=endpoint, username=username,
+                        password=password, bucket=bucket, pattern=pattern, query=query, batch_size=batch_size)
+        return dir
+
+    def getFile(self, domain):
+        username = self.cfg["hs_username"]
+        password = self.cfg["hs_password"]
+        endpoint = self.cfg["hs_endpoint"]
+        bucket = self.cfg["hs_bucket"]
+        fh = h5py.File(domain, mode='r', endpoint=endpoint, username=username,
+                    password=password, bucket=bucket, use_cache=True)
+        return fh
+
+    def visitDomains(self, domain, depth=1):
+        if depth == 0:
+            return 0
+
+        count = 0
+        if domain[-1] == '/':
+            domain = domain[:-1]  # strip off trailing slash
+
+        try:
+            dir = self.getFolder(domain + '/')
+            dir_class = "domain"
+            display_name = domain
+            num_bytes = ' '
+            if dir.is_folder:
+                dir_class = "folder"
+                display_name += '/'
+            elif self.cfg["verbose"]:
+                # get the number of allocated bytes
+                f = self.getFile(domain)
+                num_bytes = f.total_size
+                f.close()
+
+            owner = dir.owner
+            if owner is None:
+                owner = ""
+            if dir.modified is None:
+                timestamp = ""
+            else:
+                timestamp = datetime.fromtimestamp(int(dir.modified))
+
+            print("{:15} {:15} {:8} {} {}".format(owner, self.format_size(num_bytes),
+                                                dir_class, timestamp,
+                                                display_name))
+            count += 1
+            if self.cfg["showacls"]:
+                self.dumpAcls(dir)
+            for name in dir:
+                item = dir[name]
+                owner = item["owner"]
+                full_path = domain + '/' + name
+
+                num_bytes = " "
+                if self.cfg["verbose"] and "total_size" in item:
+                    num_bytes = item["total_size"]
+                else:
+                    num_bytes = " "
+                dir_class = item["class"]
+                if item["lastModified"] is None:
+                    timestamp = ""
+                else:
+                    timestamp = datetime.fromtimestamp(int(item["lastModified"]))
+
+                print("{:15} {:15} {:8} {} {}".format(owner, self.format_size(num_bytes),
+                                                dir_class, timestamp,
+                                                full_path))
+                count += 1
+
+                if dir_class == "folder":
+                    # recurse for folders
+                    n = self.visitDomains(domain + '/' + name, depth=(depth - 1))
+                    count += n
+
+        except IOError as oe:
+            if oe.errno in (403, 404, 410):
+                # TBD: recently created domains may not be immediately visible to
+                # the service Once the flush operation is implemented, this should
+                # be an issue for h5pyd apps
+                #
+                # Also, ignore domains for which we don't have permsssions (403)
+                pass
+            else:
+                print("error getting domain:", domain)
+                sys.exit(str(oe))
+
+        return count
+
+    def execute(self, domain, verbose=False, showacls=False, showattrs=False, human_readable=False, pattern=None, 
+    query=None, cmd=None, recursive=None, loglevel=logging.ERROR, logfile=None, endpoint=None, username=None, password=None, bucket=None):
+        domains = [domain]
+        self.execute(domains, verbose=verbose, showacls=showacls, showattrs=showattrs, human_readable=human_readable, pattern=pattern, query=query, 
+        cmd=cmd, recursive=recursive, loglevel=loglevel, logfile=logfile, endpoint=endpoint, username=username, password=password, bucket=bucket)
+
+    def execute(self, domains, verbose=False, showacls=False, showattrs=False, human_readable=False, pattern=None, 
+    query=None, cmd=None, recursive=None, loglevel=logging.ERROR, logfile=None, endpoint=None, username=None, password=None, bucket=None):
+        depth = 1
+        self.cfg["verbose"] = False
+        self.cfg["showacls"] = False
+        self.cfg["showattrs"] = False
+        self.cfg["human_readable"] = False
+        self.cfg["pattern"] = None
+        self.cfg["query"] = None
+        self.cfg["cmd"] = None
+        self.cfg['hs_bucket'] = None
+        
+        if verbose is not None:
+            self.cfg['verbose'] = verbose
+        if showacls is not None:
+            self.cfg['showacls'] = showacls
+        if showattrs is not None:
+            self.cfg['showattrs'] = showattrs
+        if human_readable is not None:
+            self.cfg['human_readable'] = human_readable
+        if pattern is not None:
+            self.cfg['pattern'] = pattern
+        if query is not None:
+            self.cfg['query'] = query
+        if cmd is not None:
+            self.cfg['cmd'] = cmd
+        if recursive is True:
+            depth = -1
+        if endpoint is not None:
+            self.cfg['hs_endpoint'] = endpoint
+        if username is not None:
+            self.cfg['hs_username'] = username
+        if password is not None:
+            self.cfg['hs_password'] = password
+        if bucket is not None:
+            self.cfg['hs_bucket'] = bucket
+
+        # setup logging
+        logging.basicConfig(filename=logfile, format='%(levelname)s %(asctime)s %(message)s',
+                            level=loglevel)
+        logging.debug("set log_level to {}".format(loglevel))
+
+        if len(domains) == 0:
+            # add top-level domain
+            domains.append("/")
+
+        for domain in domains:
+            if domain.endswith('/'):
+                # given a folder path
+                count = self.visitDomains(domain, depth=depth)
+                print("{} items".format(count))
+
+            else:
+                try:
+                    f = self.getFile(domain)
+                except IOError as ioe:
+                    if ioe.errno == 401:
+                        print("Username/Password missing or invalid")
+                        continue
+                    if ioe.errno == 403:
+                        print("No permission to read domain: {}".format(domain))
+                        continue
+                    elif ioe.errno == 404:
+                        print("Domain {} not found".format(domain))
+                        continue
+                    elif ioe.errno == 410:
+                        print("Domain {} has been removed".format(domain))
+                        continue
+                    else:
+                        print("Unexpected error: {}".format(ioe))
+                        continue
+
+                grp = f['/']
+                if grp is None:
+                    print("{}: No such domain".format(domain))
+                    domain += '/'
+                    count = self.visitDomains(domain, depth=depth)
+                    print("{} items".format(count))
+                    continue
+                self.dump('/', grp)
+
+                if depth < 0:
+                    # recursive
+                    visited = {}  # dict of id to h5path
+                    visited[grp.id.id] = '/'
+                    self.visititems('/', grp, visited)
+                else:
+                    for k in grp:
+                        item = grp.get(k, getlink=True)
+                        if item.__class__.__name__ == "HardLink":
+                            # follow hardlinks
+                            try:
+                                item = grp[k]
+                            except IOError:
+                                # object deleted?  Just dump link info
+                                pass
+                        self.dump(k, item)
+                if self.cfg["showacls"]:
+                    self.dumpAcls(grp)
+                grp.file.close()


### PR DESCRIPTION
Allows the hsls program to be used as a library.

+ Factored out the hsls algorithm into its own method (**_execute**)
+ Created two library methods (**listDomainContents** and **listDomainsContents**) which allow outside code to call the hsls algorithm, either with one domain or multiple domains.  Rather than have tons of configuration parameters in the library method signatures, I also created a small class called HSLS_Params that encapsulates all the possible parameters that can be passed into the library methods.  The library methods override Config values with their own parameter values if those parameter values are not set to None.  In this way, the caller of the methods can run the algorithm with their own parameters regardless of what config values are set (or choose to use the Config values by setting parameter values to None).
+ Created a parsing method (**parseCmdLineArgs**) that parses the args coming in from the main method and adds them to the Config object.
+ Updated main method to just call parseCmdLineArgs and then call _execute.

Using this PR, we are now able to call the hsls algorithm directly from a HyperThought endpoint.  Without it, we would have to spawn a subprocess to call hsls via the command line, which has its own security and technical issues.

Signed-off-by: Joey Kleingers <joey.kleingers@bluequartz.net>