### PR TITLE
HLObject is hashable now

### DIFF
--- a/h5pyd/_hl/base.py
+++ b/h5pyd/_hl/base.py
@@ -997,6 +997,9 @@ class HLObject(CommonStateObject):
         else:
             pass
 
+    def __hash__(self):
+        return hash(self.id)
+
     def __eq__(self, other):
         if hasattr(other, 'id'):
             return self.id == other.id

--- a/h5pyd/_hl/base.py
+++ b/h5pyd/_hl/base.py
@@ -998,7 +998,7 @@ class HLObject(CommonStateObject):
             pass
 
     def __hash__(self):
-        return hash(self.id)
+        return hash(self.id.id)
 
     def __eq__(self, other):
         if hasattr(other, 'id'):


### PR DESCRIPTION
This patch fixes issue #100 to make `HLObject` hashable which is compatible to `h5py`.