### PR TITLE
Corrected inline documentation for `--username` option

### DIFF
--- a/h5pyd/_apps/hsacl.py
+++ b/h5pyd/_apps/hsacl.py
@@ -53,7 +53,7 @@ def printUsage():
     print("Options:")
     print("     -v | --verbose :: verbose output")
     print("     -e | --endpoint <domain> :: The HDF Server endpoint, e.g. http://hsdshdflab.hdfgroup.org")
-    print("     -u | --user <username>   :: User name credential")
+    print("     -u | --username <username>   :: User name credential")
     print("     -p | --password <password> :: Password credential")
     print("     --logfile <logfile> :: logfile path")
     print("     --loglevel debug|info|warning|error :: Change log level")

--- a/h5pyd/_apps/hscopy.py
+++ b/h5pyd/_apps/hscopy.py
@@ -48,7 +48,7 @@ def usage():
     print("Options:")
     print("     -v | --verbose :: verbose output")
     print("     -e | --endpoint <domain> :: The HDF Server endpoint, e.g. http://hsdshdflab.hdfgroup.org")
-    print("     -u | --user <username>   :: User name credential")
+    print("     -u | --username <username>   :: User name credential")
     print("     -p | --password <password> :: Password credential")
     print("     --src_endpoint <domain> :: The HDF Server endpoint for src file")
     print("     --src_user <username>   :: User name credential for src file")

--- a/h5pyd/_apps/hsdiff.py
+++ b/h5pyd/_apps/hsdiff.py
@@ -378,7 +378,7 @@ def usage():
     print("Options:")
     print("     -v | --verbose :: verbose output")
     print("     -e | --endpoint <domain> :: The HDF Server endpoint, e.g. http://hsdshdflab.hdfgroup.org")
-    print("     -u | --user <username>   :: User name credential")
+    print("     -u | --username <username>   :: User name credential")
     print("     -p | --password <password> :: Password credential")
     print("     -c | --conf <file.cnf>  :: A credential and config file")
     print("     --cnf-eg        :: Print a config file and then exit")

--- a/h5pyd/_apps/hsget.py
+++ b/h5pyd/_apps/hsget.py
@@ -42,7 +42,7 @@ def usage():
     print("Options:")
     print("     -v | --verbose :: verbose output")
     print("     -e | --endpoint <domain> :: The HDF Server endpoint, e.g. http://hsdshdflab.hdfgroup.org")
-    print("     -u | --user <username>   :: User name credential")
+    print("     -u | --username <username>   :: User name credential")
     print("     -p | --password <password> :: Password credential")
     print("     -c | --conf <file.cnf>  :: A credential and config file")
     print("     --cnf-eg        :: Print a config file and then exit")

--- a/h5pyd/_apps/hsinfo.py
+++ b/h5pyd/_apps/hsinfo.py
@@ -28,7 +28,7 @@ def printUsage():
     print("")
     print("Options:")
     print("     -e | --endpoint <domain> :: The HDF Server endpoint, e.g. http://hsdshdflab.hdfgroup.org")
-    print("     -u | --user <username>   :: User name credential")
+    print("     -u | --username <username>   :: User name credential")
     print("     -p | --password <password> :: Password credential")
     print("     -b | --bucket <bucket> :: bucket name (for use when domain is provided)")
     print("     -c | --conf <file.cnf>  :: A credential and config file")

--- a/h5pyd/_apps/hsload.py
+++ b/h5pyd/_apps/hsload.py
@@ -57,7 +57,7 @@ def usage():
     print("Options:")
     print("     -v | --verbose :: verbose output")
     print("     -e | --endpoint <domain> :: The HDF Server endpoint, e.g. http://hsdshdflab.hdfgroup.org")
-    print("     -u | --user <username>   :: User name credential")
+    print("     -u | --username <username>   :: User name credential")
     print("     -p | --password <password> :: Password credential")
     print("     -a | --append <mode>  :: Flag to append to an existing HDF Server domain")
     print("     -c | --conf <file.cnf>  :: A credential and config file")

--- a/h5pyd/_apps/hsls.py
+++ b/h5pyd/_apps/hsls.py
@@ -360,7 +360,7 @@ def printUsage():
     print("     -v | --verbose :: verbose output")
     print("     -H | --human-readable :: with -v, print human readable sizes (e.g. 123M)")
     print("     -e | --endpoint <domain> :: The HDF Server endpoint, e.g. http://hsdshdflab.hdfgroup.org")
-    print("     -u | --user <username>   :: User name credential")
+    print("     -u | --username <username>   :: User name credential")
     print("     -p | --password <password> :: Password credential")
     print("     -c | --conf <file.cnf>  :: A credential and config file")
     print("     --showacls :: prints domain ACLs")

--- a/h5pyd/_apps/hsmv.py
+++ b/h5pyd/_apps/hsmv.py
@@ -48,7 +48,7 @@ def usage():
     print("Options:")
     print("     -v | --verbose :: verbose output")
     print("     -e | --endpoint <domain> :: The HDF Server endpoint, e.g. http://hsdshdflab.hdfgroup.org")
-    print("     -u | --user <username>   :: User name credential")
+    print("     -u | --username <username>   :: User name credential")
     print("     -p | --password <password> :: Password credential")
     print("     -c | --conf <file.cnf>  :: A credential and config file")
     print("     --cnf-eg        :: Print a config file and then exit")


### PR DESCRIPTION
The code recognized `--username`, but the inline documentation said `--user`. This aligns the documentation with the code.