### PR TITLE
Gb/lambda bugs

### DIFF
--- a/h5pyd/_hl/dataset.py
+++ b/h5pyd/_hl/dataset.py
@@ -1270,7 +1270,7 @@ class Dataset(HLObject):
         if mtype.names is not None:
             checks = [np.issubdtype(mtype[key], np.string_) for key in mtype.names]
         if any(checks):
-            self.log.info('Modifying dtypes!')
+            self.log.debug('Modifying dtypes!')
             arr_dtypes = []
             for name, check in zip(mtype.names, checks):
                 if check:


### PR DESCRIPTION
This implements a fix for json responses with non-ascii chars, specifically for lambda hsds responses. 

For some reason, when there is a json response the S30 dtype breaks on accents and other special characters. I found that you can use a <U32 dtype that works just fine. Pretty sure this doesnt break anything but you can remove the function call if it does end up being bad. 