### PR TITLE
Fix JSON encoding for dimension scales

### DIFF
--- a/h5pyd/_hl/dims.py
+++ b/h5pyd/_hl/dims.py
@@ -104,7 +104,7 @@ class DimensionProxy(base.CommonStateObject):
 
     def __init__(self, id_, dimension):
         self._id = id_
-        self._dimension = dimension
+        self._dimension = int(dimension)
 
     def __hash__(self):
         return hash((type(self), self._id, self._dimension))


### PR DESCRIPTION
Sometimes the dimension index is a NumPy scalar integer and that breaks JSON encoding of the h5pyd request. This fix ensures it is a normal Python integer always.