### PR TITLE
use surrogateescaping for non-utf8 encodable attribute values in hslo…

### DIFF
--- a/h5pyd/_hl/attrs.py
+++ b/h5pyd/_hl/attrs.py
@@ -154,7 +154,16 @@ class AttributeManager(base.MutableMappingHDF5, base.CommonStateObject):
         arr = jsonToArray(shape, htype, value_json)
 
         if len(arr.shape) == 0:
-            return arr[()]
+            v = arr[()]
+            if isinstance(v, str):
+                # if this is not utf-8, return bytes instead
+                try:
+                    v.encode("utf-8")
+                except UnicodeEncodeError:
+                    self._parent.log.debug("converting utf8 unencodable string as bytes")
+                    v = v.encode("utf-8", errors="surrogateescape")
+            return v
+
         return arr
 
     def __setitem__(self, name, value):

--- a/h5pyd/_hl/base.py
+++ b/h5pyd/_hl/base.py
@@ -284,6 +284,7 @@ def jsonToArray(data_shape, data_dtype, data_json):
                 converted_data = toTuple(np_shape_rank, data_json)
             data_json = converted_data
 
+
         arr = np.array(data_json, dtype=data_dtype)
         # raise an exception of the array shape doesn't match the selection shape
         # allow if the array is a scalar and the selection shape is one element,

--- a/test/hl/test_file.py
+++ b/test/hl/test_file.py
@@ -109,7 +109,6 @@ class TestFile(TestCase):
         self.assertEqual(f.id.id, 0)
 
         for mode in ("w-", "x"):
-            print(mode)
             try:
                 # re-open is exclusive mode (should fail)
                 h5py.File(filename, mode)
@@ -137,8 +136,8 @@ class TestFile(TestCase):
          
         # re-open as read-only
         if is_hsds:
-            wait_time = 90
-            print("waiting {} seconds for root scan sync".format(wait_time))
+            wait_time = 1 # change to >90 to test async updates
+            #print("waiting {} seconds for root scan sync".format(wait_time))
             time.sleep(wait_time)  # let async process update obj number
         f = h5py.File(filename, 'r')
         self.assertEqual(f.filename, filename)
@@ -172,7 +171,7 @@ class TestFile(TestCase):
             # check properties that are only available for h5pyd
             # Note: num_groups won't reflect current state since the
             # data is being updated asynchronously
-            if is_hsds:
+            if is_hsds and wait_time >= 90:
                 self.assertEqual(f.num_objects, 2)
                 self.assertEqual(f.num_groups, 2)
             else:


### PR DESCRIPTION
HSDS isn't able to store non-utf8 encodable attributes these values need to be transmitted and store as JSON.
This update will convert any such value using data.encode("utf-8", errors="surrogateescaping").  The value with 
get stored with \U escape codes.  On reading, the origin byte value will be returned.