### PR TITLE
Field selection for simple compound types

### DIFF
--- a/h5pyd/_hl/h5type.py
+++ b/h5pyd/_hl/h5type.py
@@ -441,10 +441,14 @@ def getTypeItem(dt):
             type_info['length'] = 'H5T_VARIABLE'
             type_info['charSet'] = 'H5T_CSET_UTF8'
             type_info['strPad'] = 'H5T_STR_NULLTERM'
-        elif vlen_check == int:
+        elif vlen_check in (int, np.int64):
             type_info['class'] = 'H5T_VLEN'
             type_info['size'] = 'H5T_VARIABLE'
             type_info['base'] = 'H5T_STD_I64'
+        elif vlen_check == np.int32:
+            type_info['class'] = 'H5T_VLEN'
+            type_info['size'] = 'H5T_VARIABLE'
+            type_info['base'] = 'H5T_STD_I32'
         elif vlen_check in (float, np.float64):
             type_info['class'] = 'H5T_VLEN'
             type_info['size'] = 'H5T_VARIABLE'
@@ -456,7 +460,7 @@ def getTypeItem(dt):
             type_info['base'] = getTypeItem(vlen_check)
         elif vlen_check is not None:
             # unknown vlen type
-            raise TypeError("Unknown h5py vlen type: " + str(vlen_check))
+            raise TypeError("Unknown h5pyd vlen type: " + str(vlen_check))
         elif ref_check is not None:
             # a reference type
             type_info['class'] = 'H5T_REFERENCE'
@@ -781,7 +785,7 @@ def createBaseDataType(typeItem):
             raise TypeError("ArrayType is not supported for variable len types")
         if 'base' not in typeItem:
             raise KeyError("'base' not provided")
-        baseType = createBaseDataType(typeItem['base'])
+        baseType = createDataType(typeItem['base'])
         dtRet = special_dtype(vlen=np.dtype(baseType))
     elif typeClass == 'H5T_OPAQUE':
         if dims:
@@ -842,9 +846,8 @@ def createBaseDataType(typeItem):
         else:
             # not a boolean enum, use h5py special dtype
             dtRet = special_dtype(enum=(dt, mapping))
-
     else:
-        raise TypeError("Invalid type class")
+        raise TypeError(f"Invalid base type class: {typeClass}")
 
     return dtRet
 

--- a/test/hl/test_datatype.py
+++ b/test/hl/test_datatype.py
@@ -12,7 +12,7 @@
 
 import numpy as np
 import math
-
+import logging
 import config
 
 if config.get("use_h5py"):
@@ -23,39 +23,11 @@ else:
 from common import ut, TestCase
 
 
-def read_dtypes(dataset_dtype, names):
-    """ Returns a 2-tuple containing:
-
-    1. Output dataset dtype
-    2. Dtype containing HDF5-appropriate description of destination
-    """
-
-    if len(names) == 0:     # Not compound, or all fields needed
-        format_dtype = dataset_dtype
-
-    elif dataset_dtype.names is None:
-        raise ValueError("Field names only allowed for compound types")
-
-    elif any(x not in dataset_dtype.names for x in names):
-        raise ValueError("Field does not appear in this type.")
-
-    else:
-        format_dtype = np.dtype([(name, dataset_dtype.fields[name][0]) for name in names])
-
-    if len(names) == 1:
-        # We don't preserve the field information if only one explicitly selected.
-        output_dtype = format_dtype.fields[names[0]][0]
-
-    else:
-        output_dtype = format_dtype
-
-    return output_dtype, format_dtype
-
-
 class TestScalarCompound(TestCase):
 
     def setUp(self):
         filename = self.getFileName("scalar_compound_dset")
+        print("filename:", filename)
         self.f = h5py.File(filename, "w")
         self.data = np.array((42.5, -118, "Hello"), dtype=[('a', 'f'), ('b', 'i'), ('c', '|S10')])
         self.dset = self.f.create_dataset('x', data=self.data)
@@ -180,4 +152,6 @@ class TestScalarCompound(TestCase):
 
 
 if __name__ == '__main__':
+    loglevel = logging.ERROR
+    logging.basicConfig(format='%(asctime)s %(message)s', level=loglevel)
     ut.main()

--- a/test/hl/test_datatype.py
+++ b/test/hl/test_datatype.py
@@ -1,0 +1,183 @@
+##############################################################################
+# Copyright by The HDF Group.                                                #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of H5Serv (HDF5 REST Server) Service, Libraries and      #
+# Utilities.  The full HDF5 REST Server copyright notice, including          #
+# terms governing use, modification, and redistribution, is contained in     #
+# the file COPYING, which can be found at the root of the source code        #
+# distribution tree.  If you do not have access to this file, you may        #
+# request a copy from help@hdfgroup.org.                                     #
+##############################################################################
+
+import numpy as np
+import math
+
+import config
+
+if config.get("use_h5py"):
+    import h5py
+else:
+    import h5pyd as h5py
+
+from common import ut, TestCase
+
+
+def read_dtypes(dataset_dtype, names):
+    """ Returns a 2-tuple containing:
+
+    1. Output dataset dtype
+    2. Dtype containing HDF5-appropriate description of destination
+    """
+
+    if len(names) == 0:     # Not compound, or all fields needed
+        format_dtype = dataset_dtype
+
+    elif dataset_dtype.names is None:
+        raise ValueError("Field names only allowed for compound types")
+
+    elif any(x not in dataset_dtype.names for x in names):
+        raise ValueError("Field does not appear in this type.")
+
+    else:
+        format_dtype = np.dtype([(name, dataset_dtype.fields[name][0]) for name in names])
+
+    if len(names) == 1:
+        # We don't preserve the field information if only one explicitly selected.
+        output_dtype = format_dtype.fields[names[0]][0]
+
+    else:
+        output_dtype = format_dtype
+
+    return output_dtype, format_dtype
+
+
+class TestScalarCompound(TestCase):
+
+    def setUp(self):
+        filename = self.getFileName("scalar_compound_dset")
+        self.f = h5py.File(filename, "w")
+        self.data = np.array((42.5, -118, "Hello"), dtype=[('a', 'f'), ('b', 'i'), ('c', '|S10')])
+        self.dset = self.f.create_dataset('x', data=self.data)
+
+    def test_ndim(self):
+        """ Verify number of dimensions """
+        self.assertEqual(self.dset.ndim, 0)
+
+    def test_shape(self):
+        """ Verify shape """
+        self.assertEqual(self.dset.shape, tuple())
+
+    def test_size(self):
+        """ Verify size """
+        self.assertEqual(self.dset.size, 1)
+
+    def test_ellipsis(self):
+        """ Ellipsis -> scalar ndarray """
+        out = self.dset[...]
+        # assertArrayEqual doesn't work with compounds; do manually
+        self.assertIsInstance(out, np.ndarray)
+        self.assertEqual(out.shape, self.data.shape)
+        self.assertEqual(out.dtype, self.data.dtype)
+
+    def test_tuple(self):
+        """ () -> np.void instance """
+        out = self.dset[()]
+        self.assertIsInstance(out, np.void)
+        self.assertEqual(out.dtype, self.data.dtype)
+
+    def test_slice(self):
+        """ slice -> ValueError """
+        with self.assertRaises(ValueError):
+            self.dset[0:4]
+
+    def test_index(self):
+        """ index -> ValueError """
+        with self.assertRaises(ValueError):
+            self.dset[0]
+
+    def test_rt(self):
+        """ Compound types are read back in correct order (h5py issue 236)"""
+
+        dt = np.dtype([('weight', np.float64),
+                       ('cputime', np.float64),
+                       ('walltime', np.float64),
+                       ('parents_offset', np.uint32),
+                       ('n_parents', np.uint32),
+                       ('status', np.uint8),
+                       ('endpoint_type', np.uint8),])
+
+        testdata = np.ndarray((16,), dtype=dt)
+        for key in dt.fields:
+            testdata[key] = np.random.random((16,)) * 100
+
+        self.f['test'] = testdata
+        outdata = self.f['test'][...]
+        self.assertTrue(np.all(outdata == testdata))
+        self.assertEqual(outdata.dtype, testdata.dtype)
+
+    def test_assign(self):
+        dt = np.dtype([('weight', (np.float64)),
+                       ('endpoint_type', np.uint8),])
+
+        testdata = np.ndarray((16,), dtype=dt)
+        for key in dt.fields:
+            testdata[key] = np.random.random(size=testdata[key].shape) * 100
+
+        ds = self.f.create_dataset('test', (16,), dtype=dt)
+        for key in dt.fields:
+            ds[key] = testdata[key]
+
+        outdata = self.f['test'][...]
+
+        self.assertTrue(np.all(outdata == testdata))
+        self.assertEqual(outdata.dtype, testdata.dtype)
+
+    def test_read(self):
+        dt = np.dtype([('weight', (np.float64)),
+                       ('endpoint_type', np.uint8),])
+
+        testdata = np.ndarray((16,), dtype=dt)
+        for key in dt.fields:
+            testdata[key] = np.random.random(size=testdata[key].shape) * 100
+
+        ds = self.f.create_dataset('test', (16,), dtype=dt)
+
+        # Write to all fields
+        ds[...] = testdata
+
+        for key in dt.fields:
+            outdata = self.f['test'][key]
+            np.testing.assert_array_equal(outdata, testdata[key])
+            self.assertEqual(outdata.dtype, testdata[key].dtype)
+
+    """
+    TBD
+    def test_nested_compound_vlen(self):
+        dt_inner = np.dtype([('a', h5py.vlen_dtype(np.int32)),
+                            ('b', h5py.vlen_dtype(np.int32))])
+
+        dt = np.dtype([('f1', h5py.vlen_dtype(dt_inner)),
+                       ('f2', np.int64)])
+
+        inner1 = (np.array(range(1, 3), dtype=np.int32),
+                  np.array(range(6, 9), dtype=np.int32))
+
+        inner2 = (np.array(range(10, 14), dtype=np.int32),
+                  np.array(range(16, 21), dtype=np.int32))
+
+        data = np.array([(np.array([inner1, inner2], dtype=dt_inner), 2),
+                        (np.array([inner1], dtype=dt_inner), 3)],
+                        dtype=dt)
+
+        self.f["ds"] = data
+        out = self.f["ds"]
+
+        # Specifying check_alignment=False because vlen fields have 8 bytes of padding
+        # because the vlen datatype in hdf5 occupies 16 bytes
+        self.assertArrayEqual(out, data, check_alignment=False)
+    """
+
+
+if __name__ == '__main__':
+    ut.main()

--- a/testall.py
+++ b/testall.py
@@ -14,6 +14,7 @@
 import os
 import sys
 
+
 hl_tests = ('test_attribute',
             'test_committedtype',
             'test_complex_numbers',
@@ -26,6 +27,7 @@ hl_tests = ('test_attribute',
             'test_dataset_pointselect',
             'test_dataset_scalar',
             'test_dataset_setitem',
+            'test_datatype',
             'test_dimscale',
             'test_file',
             'test_group',
@@ -33,6 +35,7 @@ hl_tests = ('test_attribute',
             'test_visit',
             'test_vlentype',
             'test_folder')
+
 
 app_tests = ('test_hsinfo', 'test_tall_inspect', 'test_diamond_inspect',
              'test_shuffle_inspect')


### PR DESCRIPTION
This currently has a massive performance issue with field reads. Reading 144 bytes in a field selection takes over a minute. The stall occurs when `rsp.iter_content` is invoked in `base.py`. Other calls that try to directly interact with the response, like `rsp.text` or `rsp.content` have a similar delay. 

I tried manually specifying the `utf-8` encoding for the response, since apparently having to try a bunch of encodings when one isn't specifying can sometimes cause slowdown like this, but it had no effect. 