### PR TITLE
Fix incorrect dset size for large dsets on Windows

### DIFF
--- a/h5pyd/_hl/dataset.py
+++ b/h5pyd/_hl/dataset.py
@@ -567,7 +567,7 @@ class Dataset(HLObject):
         """Numpy-style attribute giving the total dataset size"""
         if self._shape is None:
             return None
-        return numpy.prod(self._shape).item()
+        return numpy.prod(self._shape, dtype=numpy.int64).item()
 
     @property
     def nbytes(self):


### PR DESCRIPTION
`TestVeryLargeArray` creates a dataset with 2^31 elements and checks the returned shape of the dataset using `np.prod`. This works fine on Linux/OSX but runs into an issue on Windows because the default numpy integer type on Windows is 32-bit. This explicitly sets this operation to use a 64-bit int type.