### PR TITLE
support for multi-dim hyperchunking

### DIFF
--- a/h5pyd/_hl/dataset.py
+++ b/h5pyd/_hl/dataset.py
@@ -255,7 +255,6 @@ def make_new_dset(
         layout=layout,
         initializer=initializer,
         initializer_opts=initializer_opts
-
     )
 
     if fillvalue is not None:
@@ -778,7 +777,7 @@ class Dataset(HLObject):
             if "num_chunks" in rsp_json:
                 self._num_chunks = rsp_json["num_chunks"]
             else:
-                # not avaailable yet, set to 0
+                # not available yet, set to 0
                 self._num_chunks = 0
             if "allocated_size" in rsp_json:
                 self._allocated_size = rsp_json["allocated_size"]


### PR DESCRIPTION
This update enables hyperchunking for hsload --link for HSDS version 0.9.0 and greater.
For backlevel versions, ordinary 1-to-1 chunk mapping will be used.