### PR TITLE
fix retries option for hsload

### DIFF
--- a/h5pyd/_apps/hsload.py
+++ b/h5pyd/_apps/hsload.py
@@ -233,7 +233,7 @@ def main():
                     "endpoint": cfg["hs_endpoint"],
                     "bucket": cfg["hs_bucket"],
                     "mode": mode,
-                    "retries": cfg["retries"],
+                    "retries": int(cfg["retries"]),
                 }
 
                 fout = h5pyd.File(tgt, **kwargs)

--- a/h5pyd/_hl/files.py
+++ b/h5pyd/_hl/files.py
@@ -215,7 +215,7 @@ class File(Group):
             # remove the trailing slash on endpoint if it exists
             if endpoint.endswith('/'):
                 endpoint = endpoint.strip('/')
-                
+
             if username is None:
                 if "H5SERV_USERNAME" in os.environ:
                     username = os.environ["H5SERV_USERNAME"]


### PR DESCRIPTION
hsload --retries was raising a ValueError when used.  Convert option to int before passing to File object.