### PR TITLE
converting retries number to int in hslos

### DIFF
--- a/h5pyd/_apps/hsload.py
+++ b/h5pyd/_apps/hsload.py
@@ -233,7 +233,7 @@ def main():
                     "endpoint": cfg["hs_endpoint"],
                     "bucket": cfg["hs_bucket"],
                     "mode": mode,
-                    "retries": cfg["retries"],
+                    "retries": int(cfg["retries"]),
                 }
 
                 fout = h5pyd.File(tgt, **kwargs)


### PR DESCRIPTION
Currently retries valus is not converted to int which leads to error when it's provided and is actually used:

```
Traceback (most recent call last):
  File "/home/alserg/.local/bin/hsload", line 8, in <module>
    sys.exit(main())
  File "/home/alserg/.local/pipx/venvs/h5pyd/lib/python3.10/site-packages/h5pyd/_apps/hsload.py", line 290, in main
    load_file(fin, fout, **kwargs)
  File "/home/alserg/.local/pipx/venvs/h5pyd/lib/python3.10/site-packages/h5pyd/_apps/utillib.py", line 1632, in load_file
    fin.visititems(object_copy_helper)
  File "/home/alserg/.local/pipx/venvs/h5pyd/lib/python3.10/site-packages/h5py/_hl/group.py", line 668, in visititems
    return h5o.visit(self.id, proxy)
  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper
  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper
  File "h5py/h5o.pyx", line 354, in h5py.h5o.visit
  File "h5py/h5o.pyx", line 301, in h5py.h5o.cb_obj_simple
  File "/home/alserg/.local/pipx/venvs/h5pyd/lib/python3.10/site-packages/h5py/_hl/group.py", line 667, in proxy
    return func(name, self[name])
  File "/home/alserg/.local/pipx/venvs/h5pyd/lib/python3.10/site-packages/h5pyd/_apps/utillib.py", line 1604, in object_copy_helper
    write_dataset(obj, tgt, ctx)
  File "/home/alserg/.local/pipx/venvs/h5pyd/lib/python3.10/site-packages/h5pyd/_apps/utillib.py", line 1373, in write_dataset
    tgt[tgt_s] = arr
  File "/home/alserg/.local/pipx/venvs/h5pyd/lib/python3.10/site-packages/h5pyd/_hl/dataset.py", line 1584, in __setitem__
    self.PUT(req, body=body, format=format, params=params)
  File "/home/alserg/.local/pipx/venvs/h5pyd/lib/python3.10/site-packages/h5pyd/_hl/base.py", line 1007, in PUT
    rsp = self._id._http_conn.PUT(req, body=body, params=params, format=format)
  File "/home/alserg/.local/pipx/venvs/h5pyd/lib/python3.10/site-packages/h5pyd/_hl/httpconn.py", line 587, in PUT
    rsp = s.put(
  File "/home/alserg/.local/pipx/venvs/h5pyd/lib/python3.10/site-packages/requests/sessions.py", line 649, in put
    return self.request("PUT", url, data=data, **kwargs)
  File "/home/alserg/.local/pipx/venvs/h5pyd/lib/python3.10/site-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
  File "/home/alserg/.local/pipx/venvs/h5pyd/lib/python3.10/site-packages/requests/sessions.py", line 703, in send
    r = adapter.send(request, **kwargs)
  File "/home/alserg/.local/pipx/venvs/h5pyd/lib/python3.10/site-packages/requests/adapters.py", line 486, in send
    resp = conn.urlopen(
  File "/home/alserg/.local/pipx/venvs/h5pyd/lib/python3.10/site-packages/urllib3/connectionpool.py", line 938, in urlopen
    retries = retries.increment(method, url, response=response, _pool=self)
  File "/home/alserg/.local/pipx/venvs/h5pyd/lib/python3.10/site-packages/urllib3/util/retry.py", line 449, in increment
    total -= 1
TypeError: unsupported operand type(s) for -=: 'str' and 'int'
```

See https://github.com/HDFGroup/hsds/issues/332#issuecomment-2021652086 for the context