### PR TITLE
Expect scaleoffset tests to pass

### DIFF
--- a/test/hl/test_dataset.py
+++ b/test/hl/test_dataset.py
@@ -737,7 +737,6 @@ class TestCreateScaleOffset(BaseDataset):
 
     def test_float(self):
         """ Scaleoffset filter works for floating point data """
-        # TBD: Add support for scale offset filter
 
         scalefac = 4
         shape = (100, 300)

--- a/test/hl/test_dataset.py
+++ b/test/hl/test_dataset.py
@@ -735,7 +735,6 @@ class TestCreateScaleOffset(BaseDataset):
         with self.assertRaises(TypeError):
             self.f.create_dataset('foo', (20, 30), dtype=bool, scaleoffset=True)
 
-    @ut.expectedFailure
     def test_float(self):
         """ Scaleoffset filter works for floating point data """
         # TBD: Add support for scale offset filter
@@ -767,7 +766,6 @@ class TestCreateScaleOffset(BaseDataset):
         else:
             assert not (readdata == testdata).all()
 
-    @ut.expectedFailure
     def test_int(self):
         """ Scaleoffset filter works for integer data with default precision """
 
@@ -789,7 +787,6 @@ class TestCreateScaleOffset(BaseDataset):
         readdata = self.f['foo'][...]
         self.assertArrayEqual(readdata, testdata)
 
-    @ut.expectedFailure
     def test_int_with_minbits(self):
         """ Scaleoffset filter works for integer data with specified precision """
 
@@ -810,7 +807,6 @@ class TestCreateScaleOffset(BaseDataset):
         readdata = self.f['foo'][...]
         self.assertArrayEqual(readdata, testdata)
 
-    @ut.expectedFailure
     def test_int_with_minbits_lossy(self):
         """ Scaleoffset filter works for integer data with specified precision """
 


### PR DESCRIPTION
These tests have been unexpectedly passing since HDFGroup/HSDS#288, when the scaleoffset filter was allowed in DCPLs for datasets. HSDS doesn't actually do anything with the filter at present.