### PR TITLE
WIP: New HTTPConn for each obj in file

### DIFF
--- a/h5pyd/_hl/dataset.py
+++ b/h5pyd/_hl/dataset.py
@@ -1789,8 +1789,6 @@ class MultiManager():
                 if next_port > high_port:
                     next_port = low_port
 
-        # TODO: Handle the case where some or all datasets share an HTTPConn object
-
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
             # Unwrap one-selection list
             if (isinstance(args, list) and len(args) == 1):
@@ -1843,8 +1841,6 @@ class MultiManager():
             self.log.debug(msg)
             num_endpoints = 1
 
-        # TODO: Handle the case where some or all datasets share an HTTPConn object
-        # For now, assume each connection is distinct
         if (num_endpoints > 1):
             next_port = low_port
             port_len = len(ports[0])

--- a/h5pyd/_hl/group.py
+++ b/h5pyd/_hl/group.py
@@ -214,7 +214,6 @@ class Group(HLObject, MutableMappingHDF5):
             self.log.debug("create_group - iterate for link: {}".format(link))
             create_group = False
             req = "/groups/" + parent_uuid + "/links/" + link
-
             try:
                 rsp_json = self.GET(req)
             except IOError as ioe:

--- a/h5pyd/_hl/httpconn.py
+++ b/h5pyd/_hl/httpconn.py
@@ -323,6 +323,29 @@ class HttpConn:
             else:
                 self.log.error("Unknown openid provider: {}".format(provider))
 
+    def __copy__(self):
+        new_conn = HttpConn(
+            self._domain,
+            endpoint=self._endpoint,
+            username=self._username,
+            password=self._password,
+            bucket=self._bucket,
+            api_key=self._api_key,
+            mode=self._mode,
+            use_session=self._use_session,
+            use_cache=True if self._cache is not None else False,
+            logger=self._logger,
+            retries=self._retries,
+            timeout=self._timeout,
+        )
+
+        # Share object cache between connections on the same file/domain
+        if self._cache is not None:
+            new_conn._cache = self._cache
+            new_conn._objdb = self._objdb
+
+        return new_conn
+
     def __del__(self):
         if self._hsds:
             self.log.debug("hsds stop")

--- a/h5pyd/_hl/objectid.py
+++ b/h5pyd/_hl/objectid.py
@@ -14,7 +14,9 @@ from __future__ import absolute_import
 from datetime import datetime
 import pytz
 import time
+from .httpconn import HttpConn
 from .h5type import createDataType
+from copy import copy
 
 
 def parse_lastmodified(datestr):
@@ -34,7 +36,7 @@ def parse_lastmodified(datestr):
 class ObjectID:
 
     """
-        Uniquely identifies an h5serv resource
+        Uniquely identifies an HSDS resource
     """
 
     @property
@@ -103,9 +105,10 @@ class ObjectID:
         self._obj_json = item
 
         if http_conn is not None:
-            self._http_conn = http_conn
+            self._http_conn = copy(http_conn)
         elif parent_id is not None and parent_id.http_conn is not None:
-            self._http_conn = parent_id.http_conn
+            # Create new connection with same parameters as parent
+            self._http_conn = copy(parent_id.http_conn)
         else:
             raise IOError("Expected parent to have http connector")
 

--- a/test/hl/test_file.py
+++ b/test/hl/test_file.py
@@ -113,7 +113,7 @@ class TestFile(TestCase):
                 pass
 
         # re-open as read-write
-        f = h5py.File(filename, 'w')
+        f = h5py.File(filename, 'w', use_cache=False)
         self.assertTrue(f.id.id is not None)
         self.assertEqual(f.mode, 'r+')
         self.assertEqual(len(f.keys()), 0)

--- a/test/hl/test_file.py
+++ b/test/hl/test_file.py
@@ -118,13 +118,12 @@ class TestFile(TestCase):
         self.assertEqual(f.mode, 'r+')
         self.assertEqual(len(f.keys()), 0)
         root_grp = f['/']
-        # f.create_group("subgrp")
         root_grp.create_group("subgrp")
         self.assertEqual(len(f.keys()), 1)
         f.close()
         self.assertEqual(f.id.id, 0)
 
-        # rre-open in append mode
+        # re-open in append mode
         f = h5py.File(filename, "a")
         f.create_group("foo")
         del f["foo"]
@@ -135,6 +134,7 @@ class TestFile(TestCase):
             wait_time = 90  # change to >90 to test async updates
             print("waiting {wait_time:d} seconds for root scan sync".format(wait_time=wait_time))
             time.sleep(wait_time)  # let async process update obj number
+
         f = h5py.File(filename, 'r')
         self.assertEqual(f.filename, filename)
         self.assertEqual(f.name, "/")

--- a/test/hl/test_file.py
+++ b/test/hl/test_file.py
@@ -113,7 +113,10 @@ class TestFile(TestCase):
                 pass
 
         # re-open as read-write
-        f = h5py.File(filename, 'w', use_cache=False)
+        if h5py.__name__ == "h5pyd":
+            f = h5py.File(filename, 'w', use_cache=False)
+        else:
+            f = h5py.File(filename, 'w')
         self.assertTrue(f.id.id is not None)
         self.assertEqual(f.mode, 'r+')
         self.assertEqual(len(f.keys()), 0)

--- a/test/hl/test_group.py
+++ b/test/hl/test_group.py
@@ -27,7 +27,10 @@ class TestGroup(TestCase):
         # create main test file
         filename = self.getFileName("create_group")
         print("filename:", filename)
-        f = h5py.File(filename, 'w', use_cache=False)
+        if h5py.__name__ == "h5pyd":
+            f = h5py.File(filename, 'w', use_cache=False)
+        else:
+            f = h5py.File(filename, 'w')
         is_hsds = False
         if isinstance(f.id.id, str) and f.id.id.startswith("g-"):
             is_hsds = True  # HSDS has different permission defaults
@@ -281,7 +284,10 @@ class TestGroup(TestCase):
         filename = self.getFileName("test_link_removal")
         print(filename)
 
-        f = h5py.File(filename, 'w', use_cache=False)
+        if h5py.__name__ == "h5pyd":
+            f = h5py.File(filename, 'w', use_cache=False)
+        else:
+            f = h5py.File(filename, 'w')
         g1 = f.create_group("g1")
         dset = g1.create_dataset('ds', (5, 7), dtype='f4')
 

--- a/test/hl/test_group.py
+++ b/test/hl/test_group.py
@@ -27,7 +27,7 @@ class TestGroup(TestCase):
         # create main test file
         filename = self.getFileName("create_group")
         print("filename:", filename)
-        f = h5py.File(filename, 'w')
+        f = h5py.File(filename, 'w', use_cache=False)
         is_hsds = False
         if isinstance(f.id.id, str) and f.id.id.startswith("g-"):
             is_hsds = True  # HSDS has different permission defaults
@@ -281,7 +281,7 @@ class TestGroup(TestCase):
         filename = self.getFileName("test_link_removal")
         print(filename)
 
-        f = h5py.File(filename, 'w')
+        f = h5py.File(filename, 'w', use_cache=False)
         g1 = f.create_group("g1")
         dset = g1.create_dataset('ds', (5, 7), dtype='f4')
 


### PR DESCRIPTION
MultiManager generally needs multiple HttpConns in order to provide a performance boost. For multiple dsets in a single file (a common use case), the MultiManager's effectiveness was limited.

In order to avoid issues in tests with group creation/deletion not being detected, the cache must be disabled when those files are opened. For that reason, this should probably be considered a breaking API change.