### PR TITLE
Allowedmethods

### DIFF
--- a/h5pyd/_hl/httpconn.py
+++ b/h5pyd/_hl/httpconn.py
@@ -718,15 +718,7 @@ class HttpConn:
         backoff_factor = 1
         status_forcelist = (500, 502, 503, 504)
         lambda_prefix = requests_lambda.LAMBDA_REQ_PREFIX
-        allowed_methods = [
-            "HEAD",
-            "GET",
-            "PUT",
-            "DELETE",
-            "OPTIONS",
-            "TRACE",
-            "POST",
-        ]  # include POST retries
+
         if self._use_session:
             if self._s is None:
                 if self._endpoint.startswith("http+unix://"):
@@ -744,7 +736,6 @@ class HttpConn:
                     connect=retries,
                     backoff_factor=backoff_factor,
                     status_forcelist=status_forcelist,
-                    allowed_methods=allowed_methods,
                 )
 
                 s.mount(

--- a/h5pyd/_hl/httpconn.py
+++ b/h5pyd/_hl/httpconn.py
@@ -2,7 +2,7 @@
 # Copyright by The HDF Group.                                                #
 # All rights reserved.                                                       #
 #                                                                            #
-# This file is part of H5Serv (HDF5 REST Server) Service, Libraries and      #
+# This file is part of HSDS (HDF5 REST Server) Service, Libraries and      #
 # Utilities.  The full HDF5 REST Server copyright notice, including          #
 # terms governing use, modification, and redistribution, is contained in     #
 # the file COPYING, which can be found at the root of the source code        #
@@ -200,8 +200,6 @@ class HttpConn:
         if endpoint is None:
             if "HS_ENDPOINT" in os.environ:
                 endpoint = os.environ["HS_ENDPOINT"]
-            elif "H5SERV_ENDPOINT" in os.environ:
-                endpoint = os.environ["H5SERV_ENDPOINT"]
 
         if not endpoint:
             msg = "no endpoint set"
@@ -265,8 +263,6 @@ class HttpConn:
         if username is None:
             if "HS_USERNAME" in os.environ:
                 username = os.environ["HS_USERNAME"]
-            elif "H5SERV_USERNAME" in os.environ:
-                username = os.environ["H5SERV_USERNAME"]
         if isinstance(username, str) and (not username or username.upper() == "NONE"):
             username = None
         self._username = username
@@ -274,8 +270,6 @@ class HttpConn:
         if password is None:
             if "HS_PASSWORD" in os.environ:
                 password = os.environ["HS_PASSWORD"]
-            elif "H5SERV_PASSWORD" in os.environ:
-                password = os.environ["H5SERV_PASSWORD"]
         if isinstance(password, str) and (not password or password.upper() == "NONE"):
             password = None
         self._password = password


### PR DESCRIPTION
Removed allowed_methods argument to Retry due to problems with different versions of url3lib.
Effect is that retry will not be supported with DELETE, PUT and POST requests.