### PR TITLE
Fix variable length writes from non-standard shapes

### DIFF
--- a/h5pyd/_hl/dataset.py
+++ b/h5pyd/_hl/dataset.py
@@ -1369,25 +1369,29 @@ class Dataset(HLObject):
         # Generally we try to avoid converting the arrays on the Python
         # side.  However, for compound literals this is unavoidable.
         # For h5pyd, do extra check and convert type on client side for efficiency
-        vlen = check_dtype(vlen=self.dtype)
-
-        if not isinstance(val, numpy.ndarray) and vlen is not None and vlen not in (bytes, str):
+        vlen_base_class = check_dtype(vlen=self.dtype)
+        if vlen_base_class is not None and vlen_base_class not in (bytes, str):
             try:
-                val = numpy.asarray(val, dtype=vlen)
+                # Attempt to directly convert the input array of vlen data to its base class
+                val = numpy.asarray(val, dtype=vlen_base_class)
 
             except ValueError as ve:
+                # Failed to convert input array to vlen base class directly, instead create a new array where
+                # each element is an array of the Dataset's dtype
                 self.log.debug(f"asarray ValueError: {ve}")
                 try:
-                    val = numpy.array(
-                        [numpy.array(x, dtype=self.dtype) for x in val],
-                        dtype=self.dtype,
-                    )
+                    # Force output shape
+                    tmp = numpy.empty(shape=val.shape, dtype=self.dtype)
+                    tmp[:] = [numpy.array(x, dtype=self.dtype) for x in val]
+                    val = tmp
                 except ValueError as e:
                     msg = f"ValueError converting value element by element: {e}"
                     self.log.debug(msg)
 
-            if vlen == val.dtype:
+            if vlen_base_class == val.dtype:
                 if val.ndim > 1:
+                    # Reshape array to 2D, where first dim = product of all dims except last, and second dim = last dim
+                    # Then flatten it to 1D
                     tmp = numpy.empty(shape=val.shape[:-1], dtype=self.dtype)
                     tmp.ravel()[:] = [
                         i
@@ -1434,6 +1438,7 @@ class Dataset(HLObject):
             else:
                 dtype = self.dtype
                 cast_compound = False
+
             val = numpy.asarray(val, dtype=dtype, order="C")
             if cast_compound:
                 val = val.astype(numpy.dtype([(names[0], dtype)]))
@@ -1520,7 +1525,7 @@ class Dataset(HLObject):
             if self.id.uuid.startswith("d-"):
                 # server is HSDS, use binary data, use param values for selection
                 format = "binary"
-                body = arrayToBytes(val, vlen=vlen)
+                body = arrayToBytes(val, vlen=vlen_base_class)
                 self.log.debug(f"writing binary data, {len(body)}")
             else:
                 # h5serv, base64 encode, body json for selection

--- a/test/hl/test_dataset.py
+++ b/test/hl/test_dataset.py
@@ -36,14 +36,18 @@ else:
 
 
 def is_empty_dataspace(obj):
-    shape_json = obj.shape_json
-
-    if "class" not in shape_json:
-        raise KeyError()
-    if shape_json["class"] == 'H5S_NULL':
-        return True
+    if config.get('use_h5py'):
+        space = obj.get_space()
+        return (space.get_simple_extent_type() == h5py.h5s.NULL)
     else:
-        return False
+        shape_json = obj.shape_json
+
+        if "class" not in shape_json:
+            raise KeyError()
+        if shape_json["class"] == 'H5S_NULL':
+            return True
+        else:
+            return False
 
 
 class BaseDataset(TestCase):

--- a/test/hl/test_dataset.py
+++ b/test/hl/test_dataset.py
@@ -122,6 +122,10 @@ class TestCreateShape(BaseDataset):
     @ut.expectedFailure
     def test_long_double(self):
         """ Confirm that the default dtype is float """
+        # Expected failure on HSDS; skip with h5py
+        if config.get('use_h5py', True):
+            self.assertTrue(False)
+
         dset = self.f.create_dataset('foo', (63,), dtype=np.longdouble)
         if platform.machine() in ['ppc64le']:
             print(f"Storage of long double deactivated on {platform.machine()}")
@@ -132,6 +136,10 @@ class TestCreateShape(BaseDataset):
     @ut.expectedFailure
     def test_complex256(self):
         """ Confirm that the default dtype is float """
+        # Expected failure on HSDS; skip with h5py
+        if config.get('use_h5py', True):
+            self.assertTrue(False)
+
         dset = self.f.create_dataset('foo', (63,),
                                      dtype=np.dtype('complex256'))
         self.assertEqual(dset.dtype, np.dtype('complex256'))
@@ -1203,6 +1211,10 @@ class TestStrings(BaseDataset):
 
     @ut.expectedFailure
     def test_fixed_utf8(self):
+        # Expected failure on HSDS; skip with h5py
+        if config.get('use_h5py', True):
+            self.assertTrue(False)
+
         # TBD: Investigate
         dt = h5py.string_dtype(encoding='utf-8', length=5)
         ds = self.f.create_dataset('x', (100,), dtype=dt)
@@ -1365,6 +1377,10 @@ class TestCompound(BaseDataset):
 
     @ut.expectedFailure
     def test_assign(self):
+        # Expected failure on HSDS; skip with h5py
+        if config.get('use_h5py', True):
+            self.assertTrue(False)
+
         # TBD: field assignment not working
         dt = np.dtype([('weight', (np.float64, 3)),
                        ('endpoint_type', np.uint8), ])
@@ -1384,6 +1400,10 @@ class TestCompound(BaseDataset):
 
     @ut.expectedFailure
     def test_fields(self):
+        # Expected failure on HSDS; skip with h5py
+        if config.get('use_h5py', True):
+            self.assertTrue(False)
+
         # TBD: field assignment not working
         dt = np.dtype([
             ('x', np.float64),
@@ -1414,6 +1434,10 @@ class TestCompound(BaseDataset):
 class TestSubarray(BaseDataset):
     # TBD: Fix subarray
     def test_write_list(self):
+        # Expected failure on HSDS; skip with h5py
+        if config.get('use_h5py', True):
+            self.assertTrue(False)
+
         ds = self.f.create_dataset("a", (1,), dtype="3int8")
         ds[0] = [1, 2, 3]
         np.testing.assert_array_equal(ds[:], [[1, 2, 3]])
@@ -1422,6 +1446,10 @@ class TestSubarray(BaseDataset):
         np.testing.assert_array_equal(ds[:], [[4, 5, 6]])
 
     def test_write_array(self):
+        # Expected failure on HSDS; skip with h5py
+        if config.get('use_h5py', True):
+            self.assertTrue(False)
+
         ds = self.f.create_dataset("a", (1,), dtype="3int8")
         ds[0] = np.array([1, 2, 3])
         np.testing.assert_array_equal(ds[:], [[1, 2, 3]])
@@ -1589,6 +1617,10 @@ class TestAstype(BaseDataset):
 
     @ut.expectedFailure
     def test_astype_wrapper(self):
+        # Expected failure on HSDS; skip with h5py
+        if config.get('use_h5py', True):
+            self.assertTrue(False)
+
         dset = self.f.create_dataset('x', (100,), dtype='i2')
         dset[...] = np.arange(100)
         arr = dset.astype('f4')[:]
@@ -1600,6 +1632,7 @@ class TestAstype(BaseDataset):
         self.assertEqual(100, len(dset.astype('f4')))
 
 
+# TBD: Supported now?
 @ut.skip("field name not supported")
 class TestScalarCompound(BaseDataset):
 
@@ -1641,6 +1674,10 @@ class TestVlen(BaseDataset):
 
     @ut.expectedFailure
     def test_reuse_struct_from_other(self):
+        # Expected failure on HSDS; skip with h5py
+        if config.get('use_h5py', True):
+            self.assertTrue(False)
+
         # TBD: unable to resstore object array from mem buffer
         dt = [('a', int), ('b', h5py.vlen_dtype(int))]
         self.f.create_dataset('vlen', (1,), dtype=dt)
@@ -1742,6 +1779,10 @@ class TestVlen(BaseDataset):
     @ut.expectedFailure
     def test_non_contiguous_arrays(self):
         """Test that non-contiguous arrays are stored correctly"""
+        # Expected failure on HSDS; skip with h5py
+        if config.get('use_h5py', True):
+            self.assertTrue(False)
+
         # TBD: boolean type not supported
         self.f.create_dataset('nc', (10,), dtype=h5py.vlen_dtype('bool'))
         x = np.array([True, False, True, True, False, False, False])
@@ -1868,6 +1909,10 @@ class TestCommutative(BaseDataset):
         Create a h5py dataset, extract one element convert to numpy
         Check that it returns symmetric response to == and !=
         """
+        # Expected failure on HSDS; skip with h5py
+        if config.get('use_h5py', True):
+            self.assertTrue(False)
+
         # TBD: investigate
         shape = (100, 1)
         dset = self.f.create_dataset("test", shape, dtype=float,

--- a/test/hl/test_dataset.py
+++ b/test/hl/test_dataset.py
@@ -157,7 +157,7 @@ class TestCreateShape(BaseDataset):
     def test_long_double(self):
         """ Confirm that the default dtype is float """
         # Expected failure on HSDS; skip with h5py
-        if config.get('use_h5py'):
+        if config.get('use_h5py') or platform.system() == 'Windows':
             self.assertTrue(False)
 
         dset = self.f.create_dataset('foo', (63,), dtype=np.longdouble)
@@ -1671,7 +1671,13 @@ class TestScalarCompound(BaseDataset):
 
 class TestVlen(BaseDataset):
     def test_int(self):
-        dt = h5py.vlen_dtype(int)
+        if platform.system() == "Windows":
+            # default np int type is 32 bit
+            dt = h5py.vlen_dtype(np.int32)
+        else:
+            # defualt np int type is 64 bit
+            dt = h5py.vlen_dtype(np.int64)
+
         ds = self.f.create_dataset('vlen', (4,), dtype=dt)
         ds[0] = np.arange(3)
         ds[1] = np.arange(0)
@@ -1708,7 +1714,12 @@ class TestVlen(BaseDataset):
         self.f.create_dataset('vlen2', (1,), self.f['vlen']['b'][()].dtype)
 
     def test_convert(self):
-        dt = h5py.vlen_dtype(int)
+        if platform.system() == "Windows":
+            # default np int type is 32 bit
+            dt = h5py.vlen_dtype(np.int32)
+        else:
+            # defualt np int type is 64 bit
+            dt = h5py.vlen_dtype(np.int64)
         ds = self.f.create_dataset('vlen', (3,), dtype=dt)
         ds[0] = np.array([1.4, 1.2])
         ds[1] = np.array([1.2])
@@ -1725,7 +1736,13 @@ class TestVlen(BaseDataset):
         self.assertArrayEqual(ds[1], np.arange(3))
 
     def test_multidim(self):
-        dt = h5py.vlen_dtype(int)
+        if platform.system() == "Windows":
+            # default np int type is 32 bit
+            dt = h5py.vlen_dtype(np.int32)
+        else:
+            # defualt np int type is 64 bit
+            dt = h5py.vlen_dtype(np.int64)
+
         ds = self.f.create_dataset('vlen', (2, 2), dtype=dt)
         # ds[0, 0] = np.arange(1)
         ds[:, :] = np.array([[np.arange(3), np.arange(2)],

--- a/test/hl/test_dataset.py
+++ b/test/hl/test_dataset.py
@@ -26,13 +26,12 @@ import platform
 
 from common import ut, TestCase
 import config
-from h5pyd import MultiManager
 
 if config.get("use_h5py"):
-    from h5py import File, Dataset
+    from h5py import File, Dataset, MultiManager
     import h5py
 else:
-    from h5pyd import File, Dataset
+    from h5pyd import File, Dataset, MultiManager
     import h5pyd as h5py
 
 

--- a/test/hl/test_vlentype.py
+++ b/test/hl/test_vlentype.py
@@ -349,14 +349,16 @@ class TestVlenTypes(TestCase):
         e1 = np.array([1.9, 2.8, 3.7], dtype=np.float64)
 
         data = np.array([e0, e1], dtype=dtvlen)
-        try:
-            # This will fail on HSDS because data is a ndarray of shape (2,3) of floats
+
+        if isinstance(dset.id.id, str):
+            # id is str for HSDS, int for h5py
             dset[...] = data
-            if isinstance(dset.id.id, str):
-                # id is str for HSDS, int for h5py
-                self.assertTrue(False)
-        except ValueError:
-            pass  # expected
+        else:
+            try:
+                # This will fail on h5py due to a different in internal array handling.
+                dset[...] = data
+            except ValueError:
+                pass  # expected on h5py
 
         data = np.zeros((2,), dtype=dtvlen)
         data[0] = e0

--- a/testall.py
+++ b/testall.py
@@ -18,6 +18,7 @@ import sys
 hl_tests = ('test_attribute',
             'test_committedtype',
             'test_complex_numbers',
+            'test_dataset',
             'test_dataset_compound',
             'test_dataset_create',
             'test_dataset_extend',


### PR DESCRIPTION
- Add `test_dataset.py` to the testall script

This added some vlen write tests back into CI which started failing after #194. 
- To fix writes from vlen arrays of certain shapes not working, the vlen array processing now forces the output shape (see `dataset.py:1384`. 

- Skip MultiManager tests when using h5py, since those changes aren't in the main branch of h5py.
- Generalize many check in `test_dataset.py` to work with h5pyd and h5py

Resolves #197
