### PR TITLE
Multi-Link API

### DIFF
--- a/h5pyd/_hl/base.py
+++ b/h5pyd/_hl/base.py
@@ -1026,7 +1026,7 @@ class HLObject(CommonStateObject):
             rsp_json = json.loads(rsp.text)
             return rsp_json
 
-    def POST(self, req, body=None, format="json"):
+    def POST(self, req, body=None, params=None, format="json"):
         if self.id.http_conn is None:
             raise IOError("object not initialized")
 
@@ -1034,7 +1034,7 @@ class HLObject(CommonStateObject):
 
         self.log.info("POST: {} [{}]".format(req, self.id.domain))
 
-        rsp = self.id._http_conn.POST(req, body=body, format=format)
+        rsp = self.id._http_conn.POST(req, body=body, params=params, format=format)
         if rsp.status_code == 409:
             raise ValueError("name already exists")
         if rsp.status_code not in (200, 201):

--- a/h5pyd/_hl/group.py
+++ b/h5pyd/_hl/group.py
@@ -855,12 +855,20 @@ class Group(HLObject, MutableMappingHDF5):
                 raise IOError("Not found")
 
         else:
-            # delete the link, not an object
-            req = "/groups/" + self.id.uuid + "/links/" + name
+            # delete the link(s), not an object
+            if isinstance(name, list):
+                # delete multiple links
+                req = "/groups/" + self.id.uuid + "/links?titles=" + '/'.join(name)
+            else:
+                # delete single link
+                req = "/groups/" + self.id.uuid + "/links/" + name
+
         self.DELETE(req)
-        if name.find('/') == -1 and name in self._link_db:
-            # remove from link cache
-            del self._link_db[name]
+
+        for n in name:
+            if n.find('/') == -1 and n in self._link_db:
+                # remove from link cache
+                del self._link_db[name]
 
     def __len__(self):
         """ Number of members attached to this group """

--- a/h5pyd/_hl/group.py
+++ b/h5pyd/_hl/group.py
@@ -679,7 +679,7 @@ class Group(HLObject, MutableMappingHDF5):
                 tgt._name = name
         return tgt
 
-    def objectify_link_json(self, link_json):
+    def _objectify_link_Json(self, link_json):
         if "id" in link_json:
             link_obj = HardLink(link_json["id"])
         elif "h5path" in link_json and "h5domain" not in link_json:
@@ -695,7 +695,7 @@ class Group(HLObject, MutableMappingHDF5):
         """ Retrieve an item or other information.
 
         "name" given only:
-            Return the item, or "default" if it doesn't exist
+            Return the item with the given name, or "default" if nothing with that name exists
 
         "getclass" is True:
             Return the class of object (Group, Dataset, etc.), or "default"
@@ -798,13 +798,13 @@ class Group(HLObject, MutableMappingHDF5):
                             group_links = {}
 
                             for link in links[group_id]:
-                                group_links[link["title"]] = self.objectify_link_json(link)
+                                group_links[link["title"]] = self._objectify_link_Json(link)
 
                             links_out[group_id] = group_links
 
                     else:
                         for link in links:
-                            links_out[link["title"]] = self.objectify_link_json(link)
+                            links_out[link["title"]] = self._objectify_link_Json(link)
                 else:
                     raise ValueError("Can't parse server response to links query")
 

--- a/h5pyd/_hl/httpconn.py
+++ b/h5pyd/_hl/httpconn.py
@@ -437,6 +437,8 @@ class HttpConn:
         check_cache = self._cache is not None and use_cache and format == "json"
         check_cache = check_cache and params["domain"] == self._domain
         check_cache = check_cache and "select" not in params and "query" not in params
+        check_cache = check_cache and "follow_links" not in params and "pattern" not in params
+        check_cache = check_cache and "Limit" not in params and "Marker" not in params
 
         if check_cache:
             self.log.debug("httpcon - checking cache")
@@ -448,6 +450,7 @@ class HttpConn:
         self.log.info(
             f"GET: {self._endpoint + req} [{params['domain']}] timeout: {self._timeout}"
         )
+
         for k in params:
             if k != "domain":
                 v = params[k]
@@ -462,6 +465,7 @@ class HttpConn:
                 stream = False
             else:
                 stream = True
+
             rsp = s.get(
                 self._endpoint + req,
                 params=params,
@@ -497,6 +501,8 @@ class HttpConn:
 
             add_to_cache = content_type and content_type.startswith("application/json")
             add_to_cache = add_to_cache and content_length < MAX_CACHE_ITEM_SIZE and not req.endswith("/value")
+            add_to_cache = add_to_cache and "follow_links" not in params and "pattern" not in params
+            add_to_cache = add_to_cache and "Limit" not in params and "Marker" not in params
 
             if add_to_cache:
                 # add to our _cache

--- a/test/hl/test_group.py
+++ b/test/hl/test_group.py
@@ -334,6 +334,17 @@ class TestGroup(TestCase):
             self.assertTrue(name in g1)
             self.assertTrue(name in g1_clone)
 
+        # delete links with names that must be URL-encoded
+        names = ['link with spaces', 'link%', 'unicode八link']
+
+        for name in names:
+            g1[name] = g1
+
+        del g1[names]
+
+        for name in names:
+            self.assertTrue(name not in g1)
+
         f.close()
 
     def test_link_multi_create(self):
@@ -520,6 +531,17 @@ class TestGroup(TestCase):
                 self.assertTrue(name in links)
                 link = links[name]
                 self.assertEqual(link.id, group_id)
+
+        # Retrieve a set of links by name
+        names = ["link" + str(i) for i in range(5, 15)]
+        links_out = g1.get(names, getlink=True)
+
+        self.assertEqual(len(links_out), 10)
+
+        for name in names:
+            self.assertTrue(name in links_out)
+            link = links_out[name]
+            self.assertEqual(link.id, g1.id.uuid)
 
 
 class TestTrackOrder(TestCase):

--- a/test/hl/test_group.py
+++ b/test/hl/test_group.py
@@ -274,7 +274,7 @@ class TestGroup(TestCase):
             for item in grp:
                 count += 1
             return count
-        # create a file for use a link target
+        # create a file for use as a link target
         if config.get("use_h5py"):
             # for some reason this test is failing in Travis
             return
@@ -299,6 +299,40 @@ class TestGroup(TestCase):
 
         self.assertEqual(len(g1_clone), 0)
         self.assertEqual(get_count(g1_clone), 0)
+
+        f.close()
+
+    def test_link_multi_removal(self):
+        # create a file for use a link target
+        if config.get("use_h5py"):
+            return
+        filename = self.getFileName("test_link_multi_removal")
+        print(filename)
+
+        f = h5py.File(filename, 'w')
+        g1 = f.create_group("g1")
+        g1_clone = f["g1"]
+        # create multiple subgroups
+        names = ["subgroup" + str(i) for i in range(10)]
+        subgrps = []
+        for name in names:
+            subgrps.append(g1.create_group(name))
+
+        self.assertEqual(len(g1), 10)
+
+        # Remove first 5 subgroups
+        del g1[names[0:5]]
+
+        self.assertEqual(len(g1), 5)
+        self.assertEqual(len(g1_clone), 5)
+
+        for name in names[0:5]:
+            self.assertFalse(name in g1)
+            self.assertFalse(name in g1_clone)
+
+        for name in names[5:]:
+            self.assertTrue(name in g1)
+            self.assertTrue(name in g1_clone)
 
         f.close()
 

--- a/test/hl/test_group.py
+++ b/test/hl/test_group.py
@@ -275,9 +275,6 @@ class TestGroup(TestCase):
                 count += 1
             return count
         # create a file for use as a link target
-        if config.get("use_h5py"):
-            # for some reason this test is failing in Travis
-            return
         filename = self.getFileName("test_link_removal")
         print(f"filename: {filename}")
 
@@ -382,7 +379,6 @@ class TestGroup(TestCase):
         for i in range(num_links, 2 * num_links):
             if i % 2 == 0:
                 new_link = h5py.SoftLink("dummy_path_" + str(i))
-                # links.append({"h5path": "dummy_path_" + str(i)})
             else:
                 # Hard link to g1
                 new_link = g1


### PR DESCRIPTION
Adds support for the multi-link operations added in HSDS 0.9.0.

- `group.get()` now accepts `marker`, `limit`, `follow_links`, and `pattern` parameters, and targets the `GET_Links` endpoint if no link names are provided.
- `group.__delitem__` and `group.__setitem__` support removing and creating multiple links in one request, if a list of link names is provided.