### PR TITLE
Restrict numpy version for now

### DIFF
--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -23,7 +23,7 @@ kiwisolver==1.4.5
 matplotlib==3.8.4
 mccabe==0.7.0
 multidict==6.0.5
-numpy==1.26.4
+numpy>=1.26.4,<2.0.0
 packaging==24.0
 pillow==10.3.0
 pycodestyle==2.11.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ requires-python = ">=3.8"
 version = "0.18.0"
 
 dependencies = [
-    "numpy >= 1.17.3",
+    "numpy >= 1.17.3, < 2.0.0",
     "requests_unixsocket",
     "pytz",
     "pyjwt",


### PR DESCRIPTION
Numpy just had its [first major release in years](https://github.com/numpy/numpy/releases/tag/v2.0.0), with breaking changes to its API. We should eventually  add compatibility, but for now just restrict the numpy dependency to a pre-2.0.0 version.