### PR TITLE
Fix parsing of Keycloak-related client configuration options

### DIFF
--- a/h5pyd/_apps/config.py
+++ b/h5pyd/_apps/config.py
@@ -45,7 +45,21 @@ default_cfg = {
         "help": "storage Bucket to use (S3 Bucket, Azure Container, or top-level directory)",
         "choices": ["BUCKET",]
     },
-
+    "hs_keycloak_client_id": {
+        "default": None,
+        "flags": ["--keycloak-client-id",],
+        "help": "Keycloak Client ID",
+    },
+    "hs_keycloak_realm": {
+        "default": None,
+        "flags": ["--keycloak-realm",],
+        "help": "Keycloak Realm",
+    },
+    "hs_keycloak_uri": {
+        "default": None,
+        "flags": ["--keycloak-uri",],
+        "help": "Keycloak instance base URL",
+    },
     "loglevel": {
         "default": "error",
         "flags": ["--loglevel",],
@@ -128,7 +142,7 @@ class Config:
                     k = fields[0].strip()
                     v = fields[1].strip()
                     if k not in self._names:
-                        raise ValueError(f"undefined option: {name}")
+                        raise ValueError(f"undefined option: {k}")
                     if k in self._choices:
                         choices = self._choices[k]
                         if len(choices) > 1 and v not in self._choices:


### PR DESCRIPTION
This pull request addresses two issues.

#### Issue 1: Keycloak Configuration Parsing

The pull request enables parsing of the client configuration when [Keycloak-related options](https://github.com/HDFGroup/hsds/blob/master/docs/keycloak_setup.md#keycloak-client-configuration) are present. Specifically, it now supports the following options:
- `hs_keycloak_client_id`
- `hs_keycloak_realm`
- `hs_keycloak_uri`

Previously, client commands would fail with a confusing error message like the following:
```
Traceback (most recent call last):
  File "(...)/bin/hsls", line 5, in <module>
    from h5pyd._apps.hsls import main
  File "(...)/site-packages/h5pyd/_apps/hsls.py", line 17, in <module>
    cfg = Config()
          ^^^^^^^^
  File "(...)/site-packages/h5pyd/_apps/config.py", line 130, in __init__
    raise ValueError(f"undefined option: {name}")
ValueError: undefined option: ignore
```

#### Issue 2: Correcting ValueError Parameter

The second issue is related to the `ValueError` exception above, which was using the incorrect parameter. The `name` variable was mistakenly used, leading to confusion, as it was actually a list of known options generated earlier in the code (see [this line](https://github.com/HDFGroup/h5pyd/blob/master/h5pyd/_apps/config.py#L90), where it gets last set to `ignore`, the last option in `default_cfg`). The pull request corrects this by using the `k` variable, which holds the current option name being parsed (`v` holds the value).

If additional subkeys (e.g., `flags`) need to be added to the new `default_cfg` keys, please advise on where to find the necessary information.