### PR TITLE
add support for multiple coordinate selection

### DIFF
--- a/examples/multi_mgr_benchmark.py
+++ b/examples/multi_mgr_benchmark.py
@@ -50,7 +50,7 @@ def benchmark_multimanager(h5file, num=10):
         mm[query]
 
     runtime = time.time() - t0
-    print(f"Mean runtime multimanager: {runtime/num:.4f} s")
+    print(f"Mean runtime multimanager: {runtime / num:.4f} s")
     # 100ms for case with 6 datasets
 
 
@@ -75,7 +75,7 @@ def benchmark_sequential_ds(h5file, num=10):
             ds[indices]
 
     runtime = time.time() - t0
-    print(f"Mean runtime sequentially: {runtime/num:.4f} s")
+    print(f"Mean runtime sequentially: {runtime / num:.4f} s")
     # ~ 400ms for case with 6 datasests
 
 

--- a/examples/notebooks/fancy_selection.ipynb
+++ b/examples/notebooks/fancy_selection.ipynb
@@ -1,0 +1,318 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "USE_H5PY=False\n",
+    "if USE_H5PY:\n",
+    "    import h5py\n",
+    "    filepath = \"./fancy_select.h5\"\n",
+    "else:\n",
+    "    import h5pyd as h5py\n",
+    "    filepath = \"/home/test_user1/test/fancy_select.h5\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[[ 0,  1,  2,  3],\n",
+       "        [ 4,  5,  6,  7],\n",
+       "        [ 8,  9, 10, 11]],\n",
+       "\n",
+       "       [[12, 13, 14, 15],\n",
+       "        [16, 17, 18, 19],\n",
+       "        [20, 21, 22, 23]]])"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# create a numpy array\n",
+    "arr = np.arange(2*3*4).reshape(2,3,4)\n",
+    "arr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[[ 0,  1,  3],\n",
+       "        [ 4,  5,  7],\n",
+       "        [ 8,  9, 11]],\n",
+       "\n",
+       "       [[12, 13, 15],\n",
+       "        [16, 17, 19],\n",
+       "        [20, 21, 23]]])"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# fancy selection with one coordinate\n",
+    "arr[:, :, [0,1,3]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[ 1,  6, 11],\n",
+       "       [13, 18, 23]])"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# numpy allows multiple coordinate selections also\n",
+    "arr[:,[0,1,2],[1,2,3]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create a new domain/file\n",
+    "f = h5py.File(filepath, \"w\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<HDF5 dataset \"dset\": shape (5, 1000, 1000), type \"<i4\">"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# create a dataset\n",
+    "dset = f.create_dataset(\"dset\", (5, 1000, 1000), dtype=\"i4\")\n",
+    "dset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(3, 500, 500)"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# HSDS will auto-chunk the dataset\n",
+    "dset.chunks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'d-613c271a-724c7351-aa2e-3f314c-8deb03'"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dset.id.id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 1.53 s, sys: 2.28 ms, total: 1.53 s\n",
+      "Wall time: 5.23 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "# write some values to the dataset\n",
+    "for i in range(1000):\n",
+    "    dset[:, i, i] = [i, i*10, i*100, i*1000, i*10000]  # .."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([    444,    4440,   44400,  444000, 4440000], dtype=int32)"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# normal hyperslab selection\n",
+    "dset[:, 444, 444]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[      0,     444,       0],\n",
+       "       [      0,    4440,       0],\n",
+       "       [      0,   44400,       0],\n",
+       "       [      0,  444000,       0],\n",
+       "       [      0, 4440000,       0]], dtype=int32)"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# fancyselection with single coordinate (works with h5py and h5pyd)\n",
+    "dset[:, 444, [333,444,555]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[      0,       0,     444],\n",
+       "       [      0,       0,    4440],\n",
+       "       [      0,       0,   44400],\n",
+       "       [      0,       0,  444000],\n",
+       "       [      0,       0, 4440000]], dtype=int32)"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# coordinates need to be increasing with h5py (though not with h5pyd)\n",
+    "dset[:, 444, [333, 555, 444]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[      1,      10,     100],\n",
+       "       [     10,     100,    1000],\n",
+       "       [    100,    1000,   10000],\n",
+       "       [   1000,   10000,  100000],\n",
+       "       [  10000,  100000, 1000000]], dtype=int32)"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# fancyselection with multiple coordinates (only works with h5pyd)\n",
+    "dset[:, [1,10,100],[1,10,100]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# close file\n",
+    "f.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "h5",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/notebooks/swmr_example.ipynb
+++ b/examples/notebooks/swmr_example.ipynb
@@ -6,8 +6,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import h5pyd\n",
-    "import numpy as np"
+    "import numpy as np\n",
+    "USE_H5PY=False\n",
+    "if USE_H5PY:\n",
+    "    import h5py\n",
+    "    filepath = \"./refresh_test.h5\"\n",
+    "else:\n",
+    "    import h5pyd as h5py\n",
+    "    filepath = \"/home/test_user1/test/refresh_test.h5\""
    ]
   },
   {
@@ -16,8 +22,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "DOMAIN_PATH = \"/home/test_user1/test/refresh_test.h5\"\n",
-    "f = h5pyd.File(DOMAIN_PATH, \"w\", libver=\"latest\")"
+    "f = h5py.File(filepath, \"w\", libver=\"latest\")"
    ]
   },
   {
@@ -57,7 +62,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "g = h5pyd.File(DOMAIN_PATH, swmr_mode=True)  # read-only file handles need to set swmr mode in the constructor"
+    "g = h5py.File(filepath, swmr=True)  # read-only file handles need to set swmr mode in the constructor"
    ]
   },
   {
@@ -85,9 +90,22 @@
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[0, 0, 0, 0],\n",
+       "       [0, 0, 0, 0],\n",
+       "       [0, 0, 0, 0]], dtype=int32)"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "dset_f.resize((6, 8))  # Resize the dataset using the writable file handle"
+    "dset_g[:,:]  # all zeros"
    ]
   },
   {
@@ -98,7 +116,9 @@
     {
      "data": {
       "text/plain": [
-       "<HDF5 dataset \"dset\": shape (3, 4), type \"<i4\">"
+       "array([[ 0,  0,  0,  0],\n",
+       "       [ 1,  2,  4,  8],\n",
+       "       [ 2,  4,  8, 16]], dtype=int32)"
       ]
      },
      "execution_count": 8,
@@ -107,7 +127,10 @@
     }
    ],
    "source": [
-    "dset_g  # the read-only reference to the dataset doesn't \"see\" the shape change yet"
+    "# write some values to the dataset\n",
+    "for i in range(3):\n",
+    "    dset_f[i,:] = [i, i*2, i*4, i*8]\n",
+    "dset_f[:,:]"
    ]
   },
   {
@@ -118,10 +141,90 @@
     {
      "data": {
       "text/plain": [
-       "<HDF5 dataset \"dset\": shape (6, 8), type \"<i4\">"
+       "array([[ 0,  0,  0,  0],\n",
+       "       [ 1,  2,  4,  8],\n",
+       "       [ 2,  4,  8, 16]], dtype=int32)"
       ]
      },
      "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# the read-only handle will show the latest values\n",
+    "# (though with h5py swmr, you might need to do a refresh to see the changes)\n",
+    "dset_g[:,:] "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[ 0,  0,  0,  0],\n",
+       "       [ 1,  2,  4,  8],\n",
+       "       [ 2,  4,  8, 16]], dtype=int32)"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# refresh will work with h5py or h5pyd\n",
+    "dset_g.refresh()\n",
+    "dset_g[:, :]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Resize the dataset using the writable file handle\n",
+    "dset_f.resize((6, 8))  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<HDF5 dataset \"dset\": shape (3, 4), type \"<i4\">"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# the read-only reference to the dataset doesn't \"see\" the shape change yet\n",
+    "#  for both h5py and h5pyd\n",
+    "dset_g  \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<HDF5 dataset \"dset\": shape (6, 8), type \"<i4\">"
+      ]
+     },
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -133,16 +236,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
+    "# create an attribute in the dataset\n",
     "dset_f.attrs[\"a1\"] = \"an attribute\"  # create an attribute"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -151,18 +255,19 @@
        "True"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "\"a1\" in dset_g.attrs  # don't need a refresh to see the attribute change from the read-only handle"
+    "# don't need a refresh to see the attribute change from the read-only handle\n",
+    "\"a1\" in dset_g.attrs"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -171,7 +276,7 @@
        "<HDF5 group \"/subgrp\" (0 members)>"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -183,43 +288,55 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "False"
+       "True"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "\"subgrp\" in g  # doesn't show up in the g reference"
+    "\"subgrp\" in g  # will show up in the g reference"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "False"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
+     "ename": "AttributeError",
+     "evalue": "'File' object has no attribute 'refresh'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[20], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mg\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrefresh\u001b[49m()  \u001b[38;5;66;03m# after a refresh, subgroup will be visible\u001b[39;00m\n\u001b[1;32m      2\u001b[0m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124msubgrp\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;129;01min\u001b[39;00m g\n",
+      "\u001b[0;31mAttributeError\u001b[0m: 'File' object has no attribute 'refresh'"
+     ]
     }
    ],
    "source": [
-    "g.refresh()  # after a refresh, subgroup will be visibile\n",
-    "\"subrp\" in g"
+    "g.refresh()  # after a refresh, subgroup will be visible\n",
+    "\"subgrp\" in g"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# close file handles\n",
+    "f.close()\n",
+    "g.close()"
    ]
   }
  ],

--- a/h5pyd/_hl/attrs.py
+++ b/h5pyd/_hl/attrs.py
@@ -250,10 +250,10 @@ class AttributeManager(base.MutableMappingHDF5, base.CommonStateObject):
     def create(self, names, values, shape=None, dtype=None):
         """ Create new attribute(s), overwriting any existing attributes.
 
-        name
-            Name of the new attribute (required)
-        data
-            An array to initialize the attribute (required)
+        names
+            Name of the new attribute or list of names (required)
+        values
+            Array to initialize the attribute or list of arrays (required)
         shape
             Shape of the attribute.  Overrides data.shape if both are
             given, in which case the total number of points must be unchanged.


### PR DESCRIPTION
Enables multi coordinate selection. e.g.: `dset[:, [1,2,3],[9,8,7]`
Requires latest HSDS from master.