### PR TITLE
fix for hsload - combine --fastlink with --linkpath

### DIFF
--- a/h5pyd/_apps/hsload.py
+++ b/h5pyd/_apps/hsload.py
@@ -137,7 +137,7 @@ def main():
     logging.basicConfig(filename=logfname, format='%(levelname)s %(asctime)s %(message)s', level=loglevel)
     logging.debug(f"set log_level to {loglevel}")
 
-    if cfg["linkpath"] and not cfg["link"]:
+    if cfg["linkpath"] and not (cfg["link"] or cfg["fastlink"]):
         abort("--linkpath option can only be used with --link")
 
     if cfg["extend_offset"] and cfg["extend_dim"] is None:


### PR DESCRIPTION
Update to hsload to allow these two options to be used together.