### PR TITLE
replace logging.warn with warning

### DIFF
--- a/h5pyd/_apps/hsacl.py
+++ b/h5pyd/_apps/hsacl.py
@@ -18,6 +18,11 @@ if __name__ == "__main__":
 else:
     from .config import Config
 
+
+def eprint(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
+
+
 cfg = Config()
 
 
@@ -49,7 +54,7 @@ def getACL(f, username="default"):
         elif ioe.errno == 404 or not ioe.errno:
             return None
         else:
-            print("unexpected error: {}".format(ioe))
+            eprint(f"unexpected error: {ioe}")
             sys.exit(1)
     if acl and "domain" in acl:
         # remove the domain key

--- a/h5pyd/_apps/hsconfigure.py
+++ b/h5pyd/_apps/hsconfigure.py
@@ -1,10 +1,16 @@
 import os
 import json
+import sys
+
 import h5pyd
 if __name__ == "__main__":
     from config import Config
 else:
     from .config import Config
+
+
+def eprint(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
 
 
 #
@@ -21,23 +27,23 @@ def get_input(prompt):
 def saveConfig(username, password, endpoint, api_key):
 
     filepath = os.path.expanduser('~/.hscfg')
-    print("Saving config file to: {}".format(filepath))
+    print(f"Saving config file to: {filepath}")
     with open(filepath, 'w') as file:
         file.write("# HDFCloud configuration file\n")
         if endpoint:
-            file.write("hs_endpoint = {}\n".format(endpoint))
+            file.write(f"hs_endpoint = {endpoint}\n")
         else:
             file.write("hs_endpoint = \n")
         if username:
-            file.write("hs_username = {}\n".format(username))
+            file.write(f"hs_username = {username}\n")
         else:
             file.write("hs_username = \n")
         if password:
-            file.write("hs_password = {}\n".format(password))
+            file.write(f"hs_password = {password}\n")
         else:
             file.write("hs_password = \n")
         if api_key:
-            file.write("hs_api_key = {}\n".format(api_key))
+            file.write(f"hs_api_key = {api_key}\n")
         else:
             file.write("hs_api_key = \n")
 
@@ -67,7 +73,7 @@ def pingServer(username, password, endpoint, api_key):
             print("forbidden (account not setup?)")
             return False
         elif ioe.errno:
-            print("Unexpected error: {}".format(ioe.errno))
+            eprint(f"Unexpected error: {ioe.errno}")
             return False
         else:
             print("Couldn't connect to server")
@@ -103,27 +109,27 @@ def main():
     while not done:
         print("Enter new values or accept defaults in brackets with Enter.")
         print("")
-        new_endpoint = get_input("Server endpoint [{}]: ".format(hs_endpoint))
+        new_endpoint = get_input(f"Server endpoint [{hs_endpoint}]: ")
         if new_endpoint:
-            print("Updated endpoint [{}]:".format(new_endpoint))
+            print(f"Updated endpoint [{new_endpoint}]:")
             hs_endpoint = new_endpoint
             dirty = True
 
-        new_username = get_input("Username [{}]: ".format(hs_username))
+        new_username = get_input(f"Username [{hs_username}]: ")
         if new_username:
-            print("Updated username: [{}]".format(new_username))
+            print(f"Updated username: [{new_username}]")
             hs_username = new_username
             dirty = True
 
-        new_password = get_input("Password [{}]: ".format(hs_password))
+        new_password = get_input(f"Password [{hs_password}]: ")
         if new_password:
-            print("updated password: [{}]".format(new_password))
+            print(f"Updated password: [{new_password}]")
             hs_password = new_password
             dirty = True
 
-        new_api_key = get_input("API Key [{}]: ".format(hs_api_key))
+        new_api_key = get_input(f"API Key [{hs_api_key}]: ")
         if new_api_key:
-            print("updated api key: [{}]".format(new_api_key))
+            print(f"Updated api key: [{new_api_key}]")
             hs_api_key = new_api_key
             dirty = True
         if hs_api_key and hs_api_key.lower() == "none":

--- a/h5pyd/_apps/hsdiff.py
+++ b/h5pyd/_apps/hsdiff.py
@@ -48,13 +48,11 @@ def getFile(domain, mode="r"):
 
 def diff_attrs(src, tgt, ctx):
     """compare attributes of src and tgt"""
-    msg = "checking attributes of {}".format(src.name)
+    msg = f"checking attributes of {src.name}"
     logging.debug(msg)
 
     if len(src.attrs) != len(tgt.attrs):
-        msg = "<{}> have a different number of attribute from <{}>".format(
-            src.name, tgt.name
-        )
+        msg = f"<{src.name}> have a different number of attribute from <{tgt.name}>"
         logging.info(msg)
         if not ctx["quiet"]:
             print(msg)
@@ -62,14 +60,12 @@ def diff_attrs(src, tgt, ctx):
         return False
 
     for name in src.attrs:
-        msg = "checking attribute {} of {}".format(name, src.name)
+        msg = f"checking attribute {name} of {src.name}"
         logging.debug(msg)
         if ctx["verbose"]:
             print(msg)
         if name not in tgt.attrs:
-            msg = "<{}>  has attribute {} not found in <{}>".format(
-                src.name, name, tgt.name
-            )
+            msg = f"<{src.name}>  has attribute {name} not found in <{tgt.name}>"
             logging.info(msg)
             if not ctx["quiet"]:
                 print(msg)
@@ -80,33 +76,28 @@ def diff_attrs(src, tgt, ctx):
         if isinstance(src_attr, np.ndarray):
             # compare shape, type, and values
             if src_attr.dtype != tgt_attr.dtype:
-                msg = "Type of attribute {} of <{}> is different".format(name, src.name)
+                msg = f"Type of attribute {name} of <{src.name}> is different"
                 logging.info(msg)
                 if not ctx["quiet"]:
                     print(msg)
                 ctx["differences"] += 1
                 return False
             if src_attr.shape != tgt_attr.shape:
-                msg = "Shape of attribute {} of <{}> is different".format(
-                    name, src.name
-                )
+                msg = f"Shape of attribute {name} of <{src.name}> is different"
                 logging.info(msg)
                 if not ctx["quiet"]:
                     print(msg)
                 ctx["differences"] += 1
                 return False
             if hash(src_attr.tostring()) != hash(tgt_attr.tostring()):
-                msg = "values for attribute {} of <{}> differ".format(name, src.name)
-                logging.info(msg)
+                msg = f"values for attribute {name} of <{src.name}> differ"
                 if not ctx["quiet"]:
                     print(msg)
                 ctx["differences"] += 1
                 return False
         elif src_attr != tgt_attr:
             # returned as int or string, just compare values
-            msg = "<{}>  has attribute {} different than <{}>".format(
-                src.name, name, tgt.name
-            )
+            msg = f"<{src.name}>  has attribute {name} different than <{tgt.name}>"
             logging.info(msg)
 
             if not ctx["quiet"]:
@@ -120,7 +111,7 @@ def diff_attrs(src, tgt, ctx):
 
 def diff_group(src, ctx):
     """compare group in src and tgt"""
-    msg = "checking group <{}>".format(src.name)
+    msg = f"checking group <{src.name}>"
     logging.info(msg)
     if ctx["verbose"]:
         print(msg)
@@ -128,7 +119,7 @@ def diff_group(src, ctx):
     fout = ctx["fout"]
 
     if src.name not in fout:
-        msg = "<{}> not found in target".format(src.name)
+        msg = f"<{src.name}> not found in target"
         logging.info(msg)
         if not ctx["quiet"]:
             print(msg)
@@ -138,11 +129,9 @@ def diff_group(src, ctx):
     tgt = fout[src.name]
 
     # printed when there is a difference
-    output = "group: <{}> and <{}>".format(src.name, tgt.name)
+    output = f"group: <{src.name}> and <{tgt.name}>"
     if len(src) != len(tgt):
-        msg = "{} group have a different number of links from {}".format(
-            src.name, tgt.name
-        )
+        msg = f"{src.name} group have a different number of links from {tgt.name}"
         logging.info(msg)
         if ctx["verbose"]:
             print(msg)
@@ -153,11 +142,10 @@ def diff_group(src, ctx):
 
     for title in src:
         if ctx["verbose"]:
-            print("got link: '{}' of group <{}>".format(title, src.name))
+            print(f"got link: '{title}' of group <{src.name}>")
         if title not in tgt:
-            msg = "<{}> group has link {} not found in <{}>".format(
-                src.name, title, tgt.name
-            )
+            msg = f"<{src.name}> group has link {title} not found in <{tgt.name}>"
+
             logging.info(msg)
             if ctx["verbose"]:
                 print(msg)
@@ -171,9 +159,7 @@ def diff_group(src, ctx):
         lnk_tgt = tgt.get(title, getlink=True)
         lnk_tgt_type = lnk_tgt.__class__.__name__
         if lnk_src_type != lnk_tgt_type:
-            msg = "<{}> group has link {} of different type than found in <{}>".format(
-                src.name, title, tgt.name
-            )
+            msg = f"<{src.name}> group has link {title} of different type than found in <{tgt.name}>"
             logging.info(msg)
             if ctx["verbose"]:
                 print(msg)
@@ -183,17 +169,15 @@ def diff_group(src, ctx):
             return False
 
         if lnk_src_type == "HardLink":
-            logging.debug("Got hardlink: {}".format(title))
+            logging.debug(f"Got hardlink: {title}")
             # TBD: handle the case where multiple hardlinks point to same object
         elif lnk_src_type == "SoftLink":
-            msg = "Got SoftLink({}) with title: {}".format(lnk_src.path, title)
+            msg = f"Got SoftLink({lnk_src.path}) with title: {title}"
             if ctx["verbose"]:
                 print(msg)
             logging.info(msg)
             if lnk_src.path != lnk_tgt.path:
-                msg = "<{}> group has link {} with different path than <{}>".format(
-                    src.name, title, tgt.name
-                )
+                msg = f"<{src.name}> group has link {title} with different path than <{tgt.name}>"
                 if ctx["verbose"]:
                     print(msg)
                 if not ctx["quiet"]:
@@ -201,16 +185,12 @@ def diff_group(src, ctx):
                 ctx["differences"] += 1
                 return False
         elif lnk_src_type == "ExternalLink":
-            msg = "<{}> group has ExternalLink {} ({}, {})".format(
-                src.name, title, lnk_src.filename, lnk_src.path
-            )
+            msg = f"<{src.name}> group has ExternalLink {title} ({lnk_src.filename}, {lnk_src.path})"
             if ctx["verbose"]:
                 print(msg)
             logging.info(msg)
             if lnk_src.filename != lnk_tgt.filename:
-                msg = "<{}> group has external link {} with different filename than <{}>".format(
-                    src.name, title, tgt.name
-                )
+                msg = f"<{src.name}> group has external link {title} with different filename than <{tgt.name}>"
                 if ctx["verbose"]:
                     print(msg)
                 if not ctx["quiet"]:
@@ -218,9 +198,7 @@ def diff_group(src, ctx):
                 ctx["differences"] += 1
                 return False
             if lnk_src.path != lnk_tgt.path:
-                msg = "<{}> group has external link {} with different path than <{}>".format(
-                    src.name, title, tgt.name
-                )
+                msg = f"<{src.name}> group has external link {title} with different path than <{tgt.name}>"
                 if ctx["verbose"]:
                     print(msg)
                 if not ctx["quiet"]:
@@ -228,7 +206,7 @@ def diff_group(src, ctx):
                 ctx["differences"] += 1
                 return False
         else:
-            msg = "Unexpected link type: {}".format(lnk_src_type)
+            msg = f"Unexpected link type: {lnk_src_type}"
             logging.warning(msg)
             if ctx["verbose"]:
                 print(msg)
@@ -243,7 +221,7 @@ def diff_group(src, ctx):
 
 def diff_datatype(src, ctx):
     """compare datatype objects in src and tgt"""
-    msg = "checking datatype <{}>".format(src.name)
+    msg = f"checking datatype <{src.name}>"
     logging.info(msg)
     if ctx["verbose"]:
         print(msg)
@@ -251,7 +229,7 @@ def diff_datatype(src, ctx):
     fout = ctx["fout"]
 
     if src.name not in fout:
-        msg = "<{}> not found in target".format(src.name)
+        msg = f"<{src.name}> not found in target"
         logging.info(msg)
         if not ctx["quiet"]:
             print(msg)
@@ -260,7 +238,7 @@ def diff_datatype(src, ctx):
     tgt = fout[src.name]
 
     if tgt.dtype != src.dtype:
-        msg = "Type of <{}> is different".format(src.name)
+        msg = f"Type of <{src.name}> is different"
         logging.info(msg)
         if not ctx["quiet"]:
             print(msg)
@@ -276,7 +254,7 @@ def diff_datatype(src, ctx):
 
 def diff_dataset(src, ctx):
     """compare dataset in src and tgt"""
-    msg = "checking dataset <{}>".format(src.name)
+    msg = f"checking dataset <{src.name}>"
     logging.info(msg)
     if ctx["verbose"]:
         print(msg)
@@ -284,7 +262,7 @@ def diff_dataset(src, ctx):
     fout = ctx["fout"]
 
     if src.name not in fout:
-        msg = "<{}> not found in target".format(src.name)
+        msg = f"<{src.name}> not found in target"
         logging.info(msg)
         if not ctx["quiet"]:
             print(msg)
@@ -295,7 +273,7 @@ def diff_dataset(src, ctx):
     try:
         tgt_shape = tgt.shape
     except AttributeError:
-        msg = "<{}> in target not a dataset".format(src.name)
+        msg = f"<{src.name}> in target not a dataset"
         logging.info(msg)
         if not ctx["quiet"]:
             print(msg)
@@ -303,9 +281,9 @@ def diff_dataset(src, ctx):
         return False
 
     # printed when there is a difference
-    output = "dataset: <{}> and <{}>".format(src.name, tgt.name)
+    output = f"dataset: <{src.name}> and <{tgt.name}>"
     if tgt_shape != src.shape:
-        msg = "Shape of <{}> is different".format(src.name)
+        msg = f"Shape of <{src.name}> is different"
         logging.info(msg)
         if not ctx["quiet"]:
             print(output)
@@ -314,7 +292,7 @@ def diff_dataset(src, ctx):
         return False
 
     if tgt.dtype != src.dtype:
-        msg = "Type of <{}> is different".format(src.name)
+        msg = f"Type of <{src.name}> is different"
         logging.info(msg)
         if not ctx["quiet"]:
             print(output)
@@ -340,7 +318,7 @@ def diff_dataset(src, ctx):
         if is_equal:
             return True
         else:
-            msg = "values for scalar datasets {} differ".format(src.name)
+            msg = f"values for scalar datasets {src.name} differ"
             logging.info(msg)
             if not ctx["quiet"]:
                 print(msg)
@@ -360,7 +338,7 @@ def diff_dataset(src, ctx):
         if is_equal:
             return True
         else:
-            msg = "values for datasets {} differ".format(src.name)
+            msg = f"values for datasets {src.name} differ"
             logging.info(msg)
             if not ctx["quiet"]:
                 print(msg)
@@ -372,16 +350,16 @@ def diff_dataset(src, ctx):
         it = src.iter_chunks()
 
         for s in it:
-            msg = "checking dataset data for slice: {}".format(s)
+            msg = f"checking dataset data for slice: {s}"
             logging.debug(msg)
 
             arr_src = src[s]
             if len(s) > 0:
-                msg = "got src array {}".format(arr_src.shape)
+                msg = f"got src array {arr_src.shape}"
                 logging.debug(msg)
             arr_tgt = tgt[s]
             if len(s) > 0:
-                msg = "got tgt array {}".format(arr_tgt.shape)
+                msg = f"got tgt array {arr_tgt.shape}"
                 logging.debug(msg)
 
             is_equal = True
@@ -396,7 +374,7 @@ def diff_dataset(src, ctx):
                     is_equal = False
 
             if not is_equal:
-                msg = "values for dataset {} differ for slice: {}".format(src.name, s)
+                msg = f"values for dataset {src.name} differ for slice: {s}"
                 logging.info(msg)
                 if not ctx["quiet"]:
                     print(msg)
@@ -404,7 +382,7 @@ def diff_dataset(src, ctx):
                 return False
 
     except (IOError, TypeError) as e:
-        msg = "ERROR : failed to copy dataset data : {}".format(str(e))
+        msg = f"ERROR : failed to copy dataset data : {str(e)}"
         logging.error(msg)
         print(msg)
 
@@ -435,7 +413,7 @@ def diff_file(fin, fout, verbose=False, nodata=False, noattr=False, quiet=False)
         elif class_name == "Datatype":
             diff_datatype(obj, ctx)
         else:
-            logging.error("no handler for object class: {}".format(type(obj)))
+            logging.error(f"no handler for object class: {type(obj)}")
 
     # check links in root group
     diff_group(fin, ctx)

--- a/h5pyd/_apps/hsinfo.py
+++ b/h5pyd/_apps/hsinfo.py
@@ -67,13 +67,13 @@ def getUpTime(start_time):
     mins = sec // 60
     sec -= 60 * mins
     if days:
-        ret_str = "{} days, {} hours {} min {} sec".format(days, hrs, mins, sec)
+        ret_str = f"{days} days, {hrs} hours {mins} min {sec} sec"
     elif hrs:
-        ret_str = "{} hours {} min {} sec".format(hrs, mins, sec)
+        ret_str = f"{hrs} hours {min} min {sec} sec"
     elif mins:
-        ret_str = "{} min {} sec".format(mins, sec)
+        ret_str = f"{min} min {sec} sec"
     else:
-        ret_str = "{} sec".format(sec)
+        ret_str = "{sec} sec"
 
     return ret_str
 
@@ -87,17 +87,21 @@ def getServerInfo(cfg):
         info = h5pyd.getServerInfo(
             username=username, password=password, endpoint=endpoint
         )
-        print("server name: {}".format(info["name"]))
+        info_name = info["name"]
+        print(f"server name: {info_name}")
         if "state" in info:
-            print("server state: {}".format(info["state"]))
+            info_state = info["state"]
+            print(f"server state: {info_state}")
         print(f"endpoint: {endpoint}")
         if "isadmin" in info and info["isadmin"]:
             admin_tag = "(admin)"
         else:
             admin_tag = ""
 
-        print("username: {} {}".format(info["username"], admin_tag))
-        print("password: {}".format(info["password"]))
+        info_username = info["username"]
+        print(f"username: {info_username} {admin_tag}")
+        info_password = info["password"]
+        print(f"password: {info_password}")
         if info["state"] == "READY":
             try:
                 home_folder = getHomeFolder()
@@ -107,15 +111,15 @@ def getServerInfo(cfg):
                 print("home: NO ACCESS")
 
         if "hsds_version" in info:
-            print("server version: {}".format(info["hsds_version"]))
+            info_hsds_version = info["hsds_version"]
+            print(f"server version: {info_hsds_version}")
         if "node_count" in info:
-            print("node count: {}".format(info["node_count"]))
-        elif "h5serv_version" in info:
-            print("server version: {}".format(info["h5serv_version"]))
+            info_node_count = info["node_count"]
+            print(f"node count: {info_node_count}")
         if "start_time" in info:
             uptime = getUpTime(info["start_time"])
             print(f"up: {uptime}")
-        print("h5pyd version: {}".format(h5pyd.version.version))
+        print(f"h5pyd version: {h5pyd.version.version}")
 
     except IOError as ioe:
         if ioe.errno == 401:
@@ -152,10 +156,10 @@ def getHomeFolder():
                     path, username=username, password=password, endpoint=endpoint
                 )
             except IOError as ioe:
-                logging.info("find home folder - got ioe: {}".format(ioe))
+                logging.info(f"find home folder - got ioe: {ioe}")
                 continue
             except Exception as e:
-                logging.warn("find home folder - got exception: {}".format(e))
+                logging.warning(f"find home folder - got exception: {e}")
                 continue
             if f.owner == username:
                 homefolder = path

--- a/h5pyd/_apps/hsls.py
+++ b/h5pyd/_apps/hsls.py
@@ -19,9 +19,9 @@ cfg = Config()
 
 def intToStr(n):
     if cfg["human_readable"]:
-        s = "{:,}".format(n)
+        s = f"{n:,}"
     else:
-        s = "{}".format(n)
+        s = f"{n}"
     return s
 
 
@@ -38,9 +38,9 @@ def format_size(n):
             break
         n /= 1024
     if symbol == 'B':
-        return "{:7}B".format(n)
+        return f"{n:7}B"
     else:
-        return "{:7.1f}{}".format(n, symbol)
+        return f"{n:7.1f}{symbol}"
 
 
 def getShapeText(dset):
@@ -81,17 +81,17 @@ def visititems(name, grp, visited):
             except IOError:
                 # object deleted but hardlink left?
                 desc = "{Missing hardlink object}"
-                print("{0:24} {1} {2}".format(item_name, class_name, desc))
+                print(f"{item_name:24} {class_name} {desc}")
 
         elif class_name == "SoftLink":
             desc = '{' + item.path + '}'
-            print("{0:24} {1} {2}".format(item_name, class_name, desc))
+            print(f"{item_name:24} {class_name} {desc}")
         elif class_name == "ExternalLink":
             desc = '{' + item.path + '//' + item.filename + '}'
-            print("{0:24} {1} {2}".format(item_name, class_name, desc))
+            print(f"{item_name:24} {class_name} {desc}")
         else:
             desc = '{Unknown Link Type}'
-            print("{0:24} {1} {2}".format(item_name, class_name, desc))
+            print(f"{item_name:24} {class_name} {desc}")
 
 
 def getTypeStr(dt):
@@ -107,7 +107,7 @@ def dump(name, obj, visited=None):
         obj_id = obj.id.id
         if visited and obj_id in visited:
             same_as = visited[obj_id]
-            print("{0:24} {1}, same as {2}".format(name, class_name, same_as))
+            print(f"{name:24} {class_name}, same as {same_as}")
             return
     elif class_name in ("ExternalLink", "SoftLink"):
         pass
@@ -131,12 +131,13 @@ def dump(name, obj, visited=None):
         desc = '{' + obj.filename + '//' + obj.path + '}'
 
     if desc is None:
-        print("{0} {1}".format(name, class_name))
+        print(f"{name} {class_name}")
     else:
-        print("{0} {1} {2}".format(name, class_name, desc))
+        print(f"{name} {class_name} {desc}")
 
     if cfg["verbose"] and obj_id is not None:
-        print("    {0:>32}: {1}".format("UUID", obj_id))
+        uuid_str = "UUID"
+        print(f"    {uuid_str:>32}: {obj_id}")
 
     if cfg["verbose"] and is_dataset and obj.shape is not None \
             and obj.chunks is not None:
@@ -262,7 +263,8 @@ def dumpACL(acl):
         perms += 'p'
     else:
         perms += '-'
-    print("    acl: {0:24} {1}".format(acl["userName"], perms))
+    acl_username = acl["username"]
+    print(f"    acl: {acl_username:24} {perms}")
 
 
 def dumpAcls(obj):
@@ -288,12 +290,12 @@ def dumpAttrs(obj):
             rank = 0  # scalar data
         if rank > 1:
             val = "[" * rank + el + "]" * rank
-            print("   attr: {0:24} {1}".format(attr_name, val))
+            print(f"   attr: {attr_name:24} {val}")
         elif rank == 1 and attr.shape[0] > 1:
-            val = "[{},{}]".format(attr[0], el)
-            print("   attr: {0:24} {1}".format(attr_name, val))
+            val = f"[{attr[0]},{el}]"
+            print(f"   attr: {attr_name:24} {val}")
         else:
-            print("   attr: {0:24} {1}".format(attr_name, attr))
+            print(f"   attr: {attr_name:24} {attr}")
 
 
 def getFolder(domain):
@@ -371,9 +373,9 @@ def visitDomains(domain, depth=1):
             timestamp = datetime.fromtimestamp(int(d.modified))
 
         if not cfg["names_only"]:
-            print("{:35} {:15} {:8} {} {}".format(owner, format_size(num_bytes),
-                                                  dir_class, timestamp,
-                                                  display_name))
+            msg = f"{owner:35} {format_size(num_bytes):15} {dir_class:8} "
+            msg += f"{timestamp} {display_name}"
+            print(msg)
         count += 1
         if cfg["showacls"]:
             dumpAcls(d)
@@ -401,9 +403,9 @@ def visitDomains(domain, depth=1):
                 # just print the name...
                 print(full_path)
             else:
-                print("{:35} {:15} {:8} {} {}".format(owner, format_size(num_bytes),
-                                                      dir_class, timestamp,
-                                                      full_path))
+                msg = f"{owner:35} {format_size(num_bytes):15} {dir_class:8} "
+                msg += f"{timestamp} {full_path}"
+                print(msg)
             if cfg["showacls"]:
                 if dir_class == "folder":
                     with getFolder(domain + '/' + name + '/') as f:

--- a/h5pyd/_apps/utillib.py
+++ b/h5pyd/_apps/utillib.py
@@ -414,7 +414,7 @@ def copy_element(val, src_dt, tgt_dt, ctx):
                 h5path = fin_obj.name
                 if not h5path:
                     msg = "No path found for ref object"
-                    logging.warn(msg)
+                    logging.warning(msg)
                     if ctx["verbose"]:
                         print(msg)
                 else:
@@ -1401,7 +1401,7 @@ def create_dataset(dobj, ctx):
                                 logging.info(f"compression_opts: {filter_opts}")
                             else:
                                 msg = f"ignoring compression_opts for filter: {filter_name}"
-                                logging.warn(msg)
+                                logging.warning(msg)
                     else:
                         logging.warning(f"filter id {filter_id} for {dobj.name} not supported")
 
@@ -1644,7 +1644,7 @@ def create_links(gsrc, gdes, ctx):
                     # can return different id's.  This will cause HDF5 files with
                     # multilinks to not load correctly
                     msg = f"could not find map item to src id: {src_obj_id_hash}"
-                    logging.warn(msg)
+                    logging.warning(msg)
                     if ctx["verbose"]:
                         print("WARNING: " + msg)
         elif link_classname == "SoftLink":

--- a/h5pyd/_hl/base.py
+++ b/h5pyd/_hl/base.py
@@ -213,7 +213,8 @@ def copyToArray(arr, rank, index, data, vlen_base=None):
     """
     nlen = arr.shape[rank]
     if len(data) != nlen:
-        raise ValueError("Array len of {} at index: {} doesn't match data length: {}".format(nlen, index, len(data)))
+        msg = f"Array len of {nlen} at index: {index} doesn't match data length: {len(data)}"
+        raise ValueError(msg)
     for i in range(nlen):
         index[rank] = i
         if rank < len(arr.shape) - 1:
@@ -298,7 +299,7 @@ def jsonToArray(data_shape, data_dtype, data_json):
         # numpy is ok with this
         if arr.size != npoints:
             msg = "Input data doesn't match selection number of elements"
-            msg += " Expected {}, but received: {}".format(npoints, arr.size)
+            msg += f" Expected {npoints}, but received: {arr.size}"
             raise ValueError(msg)
         if arr.shape != data_shape:
             arr = arr.reshape(data_shape)  # reshape to match selection
@@ -874,7 +875,7 @@ class HLObject(CommonStateObject):
                 self._name = obj_name  # save this
             if not obj_name:
                 # query the server for the name
-                self.log.debug("querying server for name to: {}".format(self._id.id))
+                self.log.debug(f"querying server for name to: {self._id.id}")
                 req = None
                 if self._id.id.startswith("g-"):
                     req = "/groups/" + self._id.id
@@ -884,7 +885,7 @@ class HLObject(CommonStateObject):
                     req = "/datatypes/" + self._id
                 if req:
                     params = params = {"getalias": 1}
-                    self.log.info("sending get alias request for id: {}".format(self._id.id))
+                    self.log.info(f"sending get alias request for id: {self._id.id}")
                     obj_json = self.GET(req, params, use_cache=False)
                     if "alias" in obj_json:
                         alias = obj_json["alias"]
@@ -1033,13 +1034,13 @@ class HLObject(CommonStateObject):
 
         # try to do a POST to the domain
 
-        self.log.info("POST: {} [{}]".format(req, self.id.domain))
+        self.log.info(f"POST: {req} [{self.id.domain}]")
 
         rsp = self.id._http_conn.POST(req, body=body, params=params, format=format)
         if rsp.status_code == 409:
             raise ValueError("name already exists")
         if rsp.status_code not in (200, 201):
-            self.log.error("POST error - status_code: {}, reason: {}".format(rsp.status_code, rsp.reason))
+            self.log.error(f"POST error - status_code: {rsp.status_code}, reason: {rsp.reason}")
             raise IOError(rsp.reason)
 
         if 'Content-Type' in rsp.headers and rsp.headers['Content-Type'] == "application/octet-stream":
@@ -1060,7 +1061,7 @@ class HLObject(CommonStateObject):
 
         # try to do a DELETE of the resource
 
-        self.log.info("DEL: {} [{}]".format(req, self.id.domain))
+        self.log.info(f"DEL: {req} [{self.id.domain}]")
         rsp = self.id._http_conn.DELETE(req, params=params)
         # self.log.info("RSP: " + str(rsp.status_code) + ':' + rsp.text)
         if rsp.status_code != 200:

--- a/h5pyd/_hl/config.py
+++ b/h5pyd/_hl/config.py
@@ -11,6 +11,11 @@
 ##############################################################################
 import os
 import json
+import sys
+
+
+def eprint(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
 
 
 class Config:
@@ -39,7 +44,7 @@ class Config:
                         continue
                     index = line.find('=')
                     if index <= 0:
-                        print("config file: {} line: {} is not valid".format(self._config_file, line_number))
+                        eprint(f"config file: {self._config_file} line: {line_number} is not valid")
                         continue
                     k = line[:index].strip()
                     v = line[(index + 1):].strip()

--- a/h5pyd/_hl/dataset.py
+++ b/h5pyd/_hl/dataset.py
@@ -1263,7 +1263,7 @@ class Dataset(HLObject):
                     pass  # ok
                 else:
                     msg = "Fancy selection with multiple coordinates is only supported in HSDS 0.9+"
-                    self.log.warn(msg)
+                    self.log.warning(msg)
                     raise IOError(msg)
 
             params["select"] = select
@@ -1348,7 +1348,7 @@ class Dataset(HLObject):
                 elements_expected = selection.mshape[0]
                 if elements_received != elements_expected:
                     msg = f"Expected {elements_expected} elements, but got {elements_received}"
-                    self.log.warn(msg)
+                    self.log.warning(msg)
                     raise IOError(msg)
 
                 arr = numpy.frombuffer(rsp, dtype=mtype)
@@ -1356,7 +1356,7 @@ class Dataset(HLObject):
                 data = rsp["value"]
                 if len(data) != selection.mshape[0]:
                     msg = f"Expected {selection.mshape[0]} elements, but got {len(data)}"
-                    self.log.warn(msg)
+                    self.log.warning(msg)
                     raise IOError(msg)
                 arr = numpy.asarray(data, dtype=mtype, order="C")
 

--- a/h5pyd/_hl/files.py
+++ b/h5pyd/_hl/files.py
@@ -781,7 +781,7 @@ class File(Group):
             if orig_ids and orig_ids != current_ids:
                 self.log.debug(f"original dn_ids: {orig_ids}")
                 self.log.debug(f"current dn_ids: {current_ids}")
-                self.log.warn("HSDS nodes have changed")
+                self.log.warning("HSDS nodes have changed")
                 raise IOError(500, "Unexpected Error")
         self.log.info("PUT flush complete")
 

--- a/h5pyd/_hl/folders.py
+++ b/h5pyd/_hl/folders.py
@@ -222,7 +222,7 @@ class Folder:
         elif rsp.status_code != 200:
             # folder must exist
             if rsp.status_code < 500:
-                self.log.warning("status_code: {}".format(rsp.status_code))
+                self.log.warning(f"folder put status_code: {rsp.status_code}")
             else:
                 self.log.error("status_code: {}".format(rsp.status_code))
             raise IOError(rsp.status_code, rsp.reason)

--- a/h5pyd/_hl/group.py
+++ b/h5pyd/_hl/group.py
@@ -105,7 +105,7 @@ class Group(HLObject, MutableMappingHDF5):
                 if not name:
                     continue
                 if group_uuid not in objdb:
-                    self.log.warn(f"objdb search: {group_uuid} not found in objdb")
+                    self.log.warning(f"objdb search: {group_uuid} not found in objdb")
                     tgt_json = None
                     break
                 group_json = objdb[group_uuid]
@@ -177,7 +177,7 @@ class Group(HLObject, MutableMappingHDF5):
         if not objdb:
             return None
         if self.id.id not in objdb:
-            self.log.warn(f"{self.id.id} not found in objdb")
+            self.log.warning(f"{self.id.id} not found in objdb")
             return None
         group_json = objdb[self.id.id]
         return group_json["links"]
@@ -445,7 +445,7 @@ class Group(HLObject, MutableMappingHDF5):
                 dtype = numpy.float32
             if not isinstance(data, numpy.ndarray) or dtype != data.dtype:
                 data = numpy.asarray(data, order="C", dtype=dtype)
-            self.log.info("data dtype: {}".format(data.dtype))
+            self.log.info(f"data dtype: {data.dtype}")
             if len(data.shape) != 1:
                 ValueError("Table must be one-dimensional")
             if numrows and numrows != data.shape[0]:

--- a/h5pyd/_hl/httpconn.py
+++ b/h5pyd/_hl/httpconn.py
@@ -314,7 +314,7 @@ class HttpConn:
                     endpoint, config=api_key, username=username, password=password
                 )
             else:
-                self.log.error("Unknown openid provider: {}".format(provider))
+                self.log.error(f"Unknown openid provider: {provider}")
 
     def __del__(self):
         if self._hsds:
@@ -353,7 +353,7 @@ class HttpConn:
                 auth_string = b"Bearer " + token.encode("ascii")
                 headers["Authorization"] = auth_string
         elif username is not None and password is not None:
-            self.log.debug("use basic auth with username: {}".format(username))
+            self.log.debug(f"use basic auth with username: {username}")
             auth_string = username + ":" + password
             auth_string = auth_string.encode("utf-8")
             auth_string = base64.b64encode(auth_string)
@@ -425,9 +425,8 @@ class HttpConn:
             params["bucket"] = self._bucket
         if self._api_key and not isinstance(self._api_key, dict):
             params["api_key"] = self._api_key
-        self.log.debug(
-            "GET: {} [{}] bucket: {}".format(req, params["domain"], self._bucket)
-        )
+        domain = params["domain"]
+        self.log.debug(f"GET: {req} [{domain}] bucket: {self._bucket}")
 
         if format == "binary":
             headers["accept"] = "application/octet-stream"
@@ -472,11 +471,11 @@ class HttpConn:
                 timeout=self._timeout,
                 verify=self.verifyCert(),
             )
-            self.log.info("status: {}".format(rsp.status_code))
+            self.log.info(f"status: {rsp.status_code}")
             if self._hsds:
                 self._hsds.run()
         except ConnectionError as ce:
-            self.log.error("connection error: {}".format(ce))
+            self.log.error(f"connection error: {ce}")
             raise IOError("Connection Error")
         except Exception as e:
             self.log.error(f"got {type(e)} exception: {e}")
@@ -545,7 +544,7 @@ class HttpConn:
             # update invalidate everything in cache
             self._cache = {}
         if params:
-            self.log.info("PUT params: {}".format(params))
+            self.log.info(f"PUT params: {params}")
         else:
             params = {}
 
@@ -572,7 +571,7 @@ class HttpConn:
             headers["Content-Type"] = "application/json"
             data = json.dumps(body)
 
-        self.log.info("PUT: {} format: {} [{} bytes]".format(req, format, len(data)))
+        self.log.info(f"PUT: {req} format: {format} [{len(data)} bytes]")
 
         try:
             if self._hsds:
@@ -585,17 +584,17 @@ class HttpConn:
                 params=params,
                 verify=self.verifyCert(),
             )
-            self.log.info("status: {}".format(rsp.status_code))
+            self.log.info(f"status: {rsp.status_code}")
             if self._hsds:
                 self._hsds.run()
         except ConnectionError as ce:
-            self.log.error("connection error: {}".format(ce))
+            self.log.error(f"connection error: {ce}")
             raise IOError("Connection Error")
 
         if rsp.status_code == 201 and req == "/":
             self.log.info("clearing domain_json cache")
             self._domain_json = None
-        self.log.info("PUT returning: {}".format(rsp))
+        self.log.info(f"PUT returning: {rsp}")
         return rsp
 
     def POST(self, req, body=None, format="json", params=None, headers=None):
@@ -656,11 +655,11 @@ class HttpConn:
                 verify=self.verifyCert(),
             )
         except ConnectionError as ce:
-            self.log.warn("connection error: ", ce)
+            self.log.warning(f"connection error: {ce}")
             raise IOError(str(ce))
 
         if rsp.status_code not in (200, 201):
-            self.log.error("POST error: {}".format(rsp.status_code))
+            self.log.error(f"POST error: {rsp.status_code}")
 
         return rsp
 
@@ -697,9 +696,9 @@ class HttpConn:
                 params=params,
                 verify=self.verifyCert(),
             )
-            self.log.info("status: {}".format(rsp.status_code))
+            self.log.info(f"status: {rsp.status_code}")
         except ConnectionError as ce:
-            self.log.error("connection error: {}".format(ce))
+            self.log.error(f"connection error: {ce}")
             raise IOError("Connection Error")
 
         if rsp.status_code == 200 and req == "/":

--- a/h5pyd/_hl/openid.py
+++ b/h5pyd/_hl/openid.py
@@ -188,7 +188,7 @@ class AzureOpenID(OpenIDHandler):
                 code = context.acquire_user_code(resource_id, app_id)
 
         except Exception as e:
-            eprint("unable to process AD token: {}".format(e))
+            eprint(f"unable to process AD token: {e}")
             self._token = None
             self.write_token_cache()
             raise
@@ -424,8 +424,8 @@ class KeycloakOpenID(OpenIDHandler):
         rsp = requests.post(keycloak_url, data=body, headers=headers)
 
         if rsp.status_code not in (200, 201):
-            print("POST error: {}".format(rsp.status_code))
-            raise IOError("Keycloak response: {}".format(rsp.status_code))
+            print(f"POST error: {rsp.status_code}")
+            raise IOError(f"Keycloak response: {rsp.status_code}")
 
         creds = rsp.json()  # TBD: catch json format errors?
         self._token = self._parse(creds)

--- a/h5pyd/_hl/table.py
+++ b/h5pyd/_hl/table.py
@@ -188,7 +188,7 @@ class Table(Dataset):
             params["query"] = condition
             if limit > 0:
                 params["Limit"] = limit - total_rows
-            self.log.info("req - cursor: {} page_size: {}".format(cursor, page_size))
+            self.log.info(f"req - cursor: {cursor} page_size: {page_size}")
             end_row = cursor + page_size
             if end_row > stop:
                 end_row = stop
@@ -196,11 +196,11 @@ class Table(Dataset):
             selection = sel.select(self, selection_arg)
 
             sel_param = selection.getQueryParam()
-            self.log.debug("query param: {}".format(sel_param))
+            self.log.debug(f"query param: {sel_param}")
             if sel_param:
                 params["select"] = sel_param
             try:
-                self.log.debug("params: {}".format(params))
+                self.log.debug(f"params: {params}")
                 rsp = self.GET(req, params=params)
                 if isinstance(rsp, bytes):
                     # binary response
@@ -229,7 +229,7 @@ class Table(Dataset):
                             e = values[i]
                         arr[i] = tuple(e)
 
-                    self.log.info("got {} rows".format(count))
+                    self.log.info(f"got {count} rows")
                 total_rows += count
                 data.append(arr)
 
@@ -241,13 +241,13 @@ class Table(Dataset):
                     # if it is not already relatively small (1024)
                     page_size //= 2
                     page_size += 1  # bump up to avoid tiny pages in the last iteration
-                    self.log.info("Got 413, reducing page_size to: {}".format(page_size))
+                    self.log.info(f"Got 413, reducing page_size to: {page_size}")
                 else:
                     # otherwise, just raise the exception
-                    self.log.info("Unexpected exception: {}".format(ioe.errno))
+                    self.log.info(f"Unexpected exception: {ioe.errno}")
                     raise ioe
             if cursor >= stop or (limit > 0 and total_rows == limit):
-                self.log.info("completed iteration, returning: {} rows".format(len(data)))
+                self.log.info(f"completed iteration, returning: {len(data)} rows")
                 break
 
         # need some special conversion for compound types --
@@ -375,7 +375,7 @@ class Table(Dataset):
             # TBD - need to handle cases where the type shape is different
             self.log.debug("got numpy array")
             if val.dtype != self.dtype and val.dtype.shape == self.dtype.shape:
-                self.log.info("converting {} to {}".format(val.dtype, self.dtype))
+                self.log.info(f"converting {val.dtype} to {self.dtype}")
                 # convert array
                 tmp = numpy.empty(val.shape, dtype=self.dtype)
                 tmp[...] = val[...]
@@ -383,8 +383,8 @@ class Table(Dataset):
         else:
             val = numpy.asarray(val, order='C', dtype=self.dtype)
 
-        self.log.debug("rows shape: {}".format(val.shape))
-        self.log.debug("data dtype: {}".format(val.dtype))
+        self.log.debug(f"rows shape: {val.shape}")
+        self.log.debug(f"data dtype: {val.dtype}")
 
         if len(val.shape) != 1:
             raise ValueError("rows must be one-dimensional")
@@ -403,14 +403,13 @@ class Table(Dataset):
             # server is HSDS, use binary data, use param values for selection
             format = "binary"
             body = val.tobytes()
-            self.log.debug("writing binary data, {} bytes".format(len(body)))
+            self.log.debug(f"writing binary data, {len(body)} bytes")
             params["append"] = numrows
         else:
             if type(val) is not list:
                 val = val.tolist()
             val = _decode(val)
-            self.log.debug("writing json data, {} elements".format(len(val)))
-            self.log.debug("data: {}".format(val))
+            self.log.debug(f"writing json data, {len(val)} elements")
             body['value'] = val
             body['append'] = numrows
 


### PR DESCRIPTION
Replace deprecated logging.warn statements.
Cleaned up old-style .format strings