### PR TITLE
fix for updated keycloak openid-connect path

### DIFF
--- a/h5pyd/_apps/config.py
+++ b/h5pyd/_apps/config.py
@@ -141,6 +141,10 @@ class Config:
                         continue
                     k = fields[0].strip()
                     v = fields[1].strip()
+                    words = v.split()
+                    if len(words) > 1 and words[1].startswith("#"):
+                        # ignore any inline comment
+                        v = words[0]
                     if k not in self._names:
                         raise ValueError(f"undefined option: {k}")
                     if k in self._choices:

--- a/h5pyd/_hl/openid.py
+++ b/h5pyd/_hl/openid.py
@@ -380,7 +380,7 @@ class KeycloakOpenID(OpenIDHandler):
             raise KeyError("keycloak client_id not set")
 
         url = self.config['keycloak_uri']
-        url += "/auth/realms/"
+        url += "/realms/"
         url += self.config['keycloak_realm']
         url += "/protocol/openid-connect/token"
 


### PR DESCRIPTION
Keycloak is now using `http://serverdns:port/realms/{realm}/protocol/openid-connect-token` to retrieve JWT tokens
Also allow inline comments in .hscfg files
 