### PR TITLE
Update authorization header encoding

### DIFF
--- a/h5pyd/_hl/httpconn.py
+++ b/h5pyd/_hl/httpconn.py
@@ -351,14 +351,14 @@ class HttpConn:
 
             if token:
                 auth_string = b"Bearer " + token.encode("ascii")
-                headers["Authorization"] = auth_string
+                headers["Authorization"] = auth_string.decode("ascii")
         elif username is not None and password is not None:
             self.log.debug(f"use basic auth with username: {username}")
             auth_string = username + ":" + password
             auth_string = auth_string.encode("utf-8")
             auth_string = base64.b64encode(auth_string)
             auth_string = b"Basic " + auth_string
-            headers["Authorization"] = auth_string
+            headers["Authorization"] = auth_string.decode("utf-8")
         else:
             self.log.debug("no auth header")
             # no auth header


### PR DESCRIPTION
When running in [Pyodide](https://pyodide.org/) inside a browser, it appears that the request library puts the literal string value of headers in browser fetch requests.

By leaving the value as a byte string, it ends up being sent as `Authorization: b'Basic ...'`.

There are different ways to approach this isssue, but ultimately headers are strings and so this fixes the issue by decoding the value before setting the header.