### PR TITLE
Replace deprecated numpy tostring()

### DIFF
--- a/h5pyd/_apps/hsdiff.py
+++ b/h5pyd/_apps/hsdiff.py
@@ -89,7 +89,7 @@ def diff_attrs(src, tgt, ctx):
                     print(msg)
                 ctx["differences"] += 1
                 return False
-            if hash(src_attr.tostring()) != hash(tgt_attr.tostring()):
+            if hash(src_attr.tobytes()) != hash(tgt_attr.tobytes()):
                 msg = f"values for attribute {name} of <{src.name}> differ"
                 if not ctx["quiet"]:
                     print(msg)


### PR DESCRIPTION
Numpy 2.3.0 removed ndarray.tostring(), which has been a deprecated alias for ndarray.tobytes() for several versions. Replace usage in h5diff with `tobytes()`. Shouldn't result in any change in behavior.

Fixes hdfgroup/hsds#426