### PR TITLE
Remove unused dependencies from configuration files

### DIFF
--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -5,8 +5,6 @@ aiosignal==1.3.1
 attrs==23.2.0
 botocore==1.34.69
 build==1.2.1
-certifi==2024.7.4
-charset-normalizer==3.3.2
 cycler==0.12.1
 flake8==7.0.0
 fonttools==4.51.0
@@ -15,7 +13,6 @@ fsspec==2024.3.1
 h5netcdf==1.3.0
 h5py==3.11.0
 h5pyd @ git+https://github.com/hdfgroup/h5pyd
-idna==3.7
 ipykernel==6.29.4
 jmespath==1.0.1
 kiwisolver==1.4.5
@@ -27,7 +24,6 @@ packaging==24.0
 pillow==10.3.0
 pycodestyle==2.11.1
 pyflakes==3.2.0
-PyJWT==2.8.0
 pyparsing==3.1.2
 pyproject_hooks==1.0.0
 python-dateutil==2.9.0.post0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ dependencies = [
     "numpy >=2.0.0rc1; python_version>='3.9'",
     "requests_unixsocket",
     "pytz",
-    "pyjwt",
     "packaging"
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,9 +11,7 @@ azure-storage-blob==12.24.0
 bitshuffle==0.5.2
 botocore==1.34.106
 build==1.2.2.post1
-certifi==2024.8.30
 cffi==1.17.1
-charset-normalizer==3.4.0
 comm==0.2.2
 contourpy==1.3.1
 cryptography==44.0.0
@@ -28,7 +26,6 @@ fsspec==2024.10.0
 h5py==3.12.1
 h5pyd @ file:///home/jreadey/repos/h5pyd
 hsds==0.9.1
-idna==3.10
 importlib_resources==6.4.5
 ipykernel==6.29.5
 ipython==8.30.0
@@ -57,7 +54,6 @@ pure_eval==0.2.3
 pycparser==2.22
 pyflakes==3.2.0
 Pygments==2.18.0
-PyJWT==2.10.1
 pyparsing==3.2.0
 pyproject_hooks==1.2.0
 python-dateutil==2.9.0.post0


### PR DESCRIPTION
As part of our ongoing research on Python dependency management, we identified a potential improvement in your project’s approach.

Specifically, the dependencies  `certifi`, `PyJWT` and `idna` are listed in `requirements.txt`, `.devcontainer/requirements.txt` and `setup.py`, but don’t appear to be used anywhere in the codebase. Additionally, `charset-normalizer` is a transitive dependency of `requests` and does not need to be listed explicitly.

Cleaning them up can make your project easier to maintain and a bit safer in the long run.

Hope this is helpful!