### PR TITLE
use timeout for PUT, POST, and DELETE in addition to GET

### DIFF
--- a/h5pyd/_hl/httpconn.py
+++ b/h5pyd/_hl/httpconn.py
@@ -35,10 +35,7 @@ def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
 
 
-DEFAULT_TIMEOUT = (
-    10,
-    1000,
-)  # #20  # 180  # seconds - allow time for hsds service to bounce
+DEFAULT_TIMEOUT = 180  # seconds - allow time for hsds service to bounce
 
 
 class CacheResponse(object):
@@ -582,6 +579,7 @@ class HttpConn:
                 data=data,
                 headers=headers,
                 params=params,
+                timeout=self._timeout,
                 verify=self.verifyCert(),
             )
             self.log.info(f"status: {rsp.status_code}")
@@ -652,6 +650,7 @@ class HttpConn:
                 data=data,
                 headers=headers,
                 params=params,
+                timeout=self._timeout,
                 verify=self.verifyCert(),
             )
         except ConnectionError as ce:
@@ -694,6 +693,7 @@ class HttpConn:
                 self._endpoint + req,
                 headers=headers,
                 params=params,
+                timeout=self._timeout,
                 verify=self.verifyCert(),
             )
             self.log.info(f"status: {rsp.status_code}")


### PR DESCRIPTION
The timeout parameter if File.__init__ is used for GET requests, but not PUT, POST, or DELETE.
This change uses the same value for all http actions.  
Fix for #268 