### PR TITLE
Replace deprecated Version._version call

### DIFF
--- a/h5pyd/version.py
+++ b/h5pyd/version.py
@@ -12,7 +12,7 @@
 
 from __future__ import absolute_import
 
-from packaging.version import Version, parse
+from packaging.version import parse
 import sys
 import numpy
 
@@ -20,13 +20,25 @@ version = "0.24.0"
 
 hdf5_version = "REST"
 
-_exp = parse(version)
+_pversion = parse(version)
 
-version_tuple = _exp._version + (
-    ("".join(str(x) for x in _exp.pre),)
-    if _exp.is_prerelease
-    else ("",)
-)
+_suffix = ""
+if _pversion.pre is not None:
+    _suffix += "".join(str(x) for x in _pversion.pre)
+if _pversion.post is not None:
+    if _suffix:
+        _suffix += "."
+    _suffix += f"post{_pversion.post}"
+if _pversion.dev is not None:
+    if _suffix:
+        _suffix += "."
+    _suffix += f"dev{_pversion.dev}"
+if _pversion.local is not None:
+    if _suffix:
+        _suffix += "+"
+    _suffix += str(_pversion.local)
+
+version_tuple = (_pversion.major, _pversion.minor, _pversion.micro, _suffix)
 
 api_version_tuple = (0, 24, 0)
 api_version = "0.24.0"


### PR DESCRIPTION
Closes https://github.com/HDFGroup/h5pyd/issues/283

In addition the version tuple is back to the initial distutils format `(major, minor, micro, suffix)`.

See https://github.com/HDFGroup/h5pyd/issues/283#issuecomment-4756639588 for more details on the original format and https://github.com/HDFGroup/h5pyd/issues/283#issuecomment-4756736861 for examples of the proposed tuple format.

Note that this PR supports all PEP 440 versions except [version epochs](https://peps.python.org/pep-0440/#version-epochs).
