### PR TITLE
Repair the devcontainer requirements

### DIFF
--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -1,7 +1,7 @@
 aiobotocore==2.12.3
 aiohttp==3.14.3
 aioitertools==0.11.0
-aiosignal==1.3.1
+aiosignal==1.4.0
 attrs==23.2.0
 botocore==1.34.69
 build==1.2.1
@@ -29,10 +29,10 @@ pyproject_hooks==1.0.0
 python-dateutil==2.9.0.post0
 pytz==2024.1
 requests==2.33.0
-requests-unixsocket==0.3.0
+requests-unixsocket==0.4.1
 s3fs==2024.3.1
 six==1.16.0
 urllib3==2.7.0
 wrapt==1.16.0
 xarray==2024.5.0
-yarl==1.9.4
+yarl==1.24.5


### PR DESCRIPTION
`pip install -r .devcontainer/requirements.txt` has failed outright since aiohttp was bumped to 3.14.3 on 2026-08-13 — it needs `aiosignal>=1.4.0` and `yarl>=1.17.0`, while the file pinned 1.3.1 and 1.9.4.

`requests-unixsocket` was also still at 0.3.0, which does not work with the requests/urllib3 versions the file pins (`InvalidURL: Not supported URL scheme http+unix`). The root `requirements.txt` moved to 0.4.1 with #430; this file never followed.

Verified in a clean venv: resolves, h5pyd imports, and a real unix-socket request returns 200.